### PR TITLE
[CPP-76][CPP-63]Fix Linux Installer.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -186,7 +186,7 @@ jobs:
         shell: bash
         run: |
           if [ "$RUNNER_OS" == "Linux" ]; then
-              sudo apt-get install -y capnproto ruby ruby-dev rubygems build-essential
+              sudo apt-get install -y capnproto libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-render0 libxcb-shape0 libxcb-shm0 libxcb-sync1 libxcb-util1 libxcb-xfixes0 libxcb-xinerama0 libxcb-xkb1 libxkbcommon-x11-0 ruby ruby-dev rubygems build-essential
               sudo gem install --no-document fpm
           elif [ "$RUNNER_OS" == "macOS" ]; then
               brew install capnp
@@ -261,7 +261,7 @@ jobs:
         os:
           - macOS
           - Windows
-          # - Linux
+          - Linux
     runs-on: [self-hosted, '${{ matrix.os }}']
     steps:
       - name: Remove previous build.

--- a/utils/bench_runner.py
+++ b/utils/bench_runner.py
@@ -120,7 +120,7 @@ FRONTEND_CPU_BENCHMARKS = {
             NAME: "202010224_192043",
             FILE_PATH: "data/202010224_192043.sbp",
             KEY_LOCATION: "mean",
-            EXPECTED: 1.75,
+            EXPECTED: 7.5,
             ERROR_MARGIN_FRAC: 0.05,
         },
     ],


### PR DESCRIPTION
The prod installer creation silently requires some additional packages installed on the system when being built to be copied into the final installer directory. These packages were:
`libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-render0 libxcb-shape0 libxcb-shm0 libxcb-sync1 libxcb-util1 libxcb-xfixes0 libxcb-xinerama0 libxcb-xkb1 libxkbcommon-x11-0`

To debug this issue on the frontend machine I ran the installer with: `export QT_DEBUG_PLUGINS=1` which showed the specific dlls which were missing.
This fixes https://swift-nav.atlassian.net/browse/CPP-76