### PR TITLE
enable antialiasing for the tracking view

### DIFF
--- a/resources/TrackingTabComponents/TrackingSignalsTab.qml
+++ b/resources/TrackingTabComponents/TrackingSignalsTab.qml
@@ -133,7 +133,7 @@ Item {
                                 line.color = colors[idx];
                                 line.width = 1;
                                 line.axisYRight = trackingSignalsYAxis;
-                                line.useOpenGL = true;
+                                // line.useOpenGL = true; // [CPP-93] Invesigate usage of `useOpenGL` in plots
                                 lines[idx] = [line, labels[idx]];
                             }
                         } else {
@@ -141,7 +141,7 @@ Item {
                             line.color = colors[idx];
                             line.width = 1;
                             line.axisYRight = trackingSignalsYAxis;
-                            line.useOpenGL = true;
+                            // line.useOpenGL = true; // [CPP-93] Invesigate usage of `useOpenGL` in plots
                             lines.push([line, labels[idx]]);
                         }
                     }

--- a/resources/view.qml
+++ b/resources/view.qml
@@ -104,14 +104,14 @@ ApplicationWindow {
                                 name: "Horizontal [m/s]"
                                 axisX: x_axis
                                 axisY: y_axis
-                                useOpenGL: true
+                                // useOpenGL: true // [CPP-93] Invesigate usage of `useOpenGL` in plots
                             }
                             LineSeries {
                                 id: vseries
                                 name: "Vertical [m/s]"
                                 axisX: x_axis
                                 axisY: y_axis
-                                useOpenGL: true
+                                // useOpenGL: true // [CPP-93] Invesigate usage of `useOpenGL` in plots
                             }
 
                             Timer {


### PR DESCRIPTION
+ setting "antialiasing" on the chart gets rid of the jagged / tearing artifacts I was seeing on my machine

+ setting the useOpenGL property reduces CPU usage from 2-3% to 0.5-1% on my machine