### PR TITLE
[CPP-126]Add retry to Mac dmg creation.

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -220,7 +220,7 @@ cp -r main.dist/* main.app/Contents/MacOS/
 iconutil --convert icns src/main/icons/Mac.iconset
 mv src/main/icons/Mac.icns main.app/Contents/Resources/SwiftNavConsole.icns
 conda run -n $CONDA_ENV python src/build/generate-mac-info-plist.py
-hdiutil create -volname SwiftNavConsole -srcfolder main.app -ov -format UDZO 'swift_navigation_console.dmg'
+hdiutil create -volname SwiftNavConsole -srcfolder main.app -ov -format UDZO 'swift_navigation_console.dmg' || (echo 'Failed to create Mac dmg. Retrying in 10s...' && sleep 10 && hdiutil create -volname SwiftNavConsole -srcfolder main.app -ov -format UDZO 'swift_navigation_console.dmg' )
 '''
 
 [tasks.qml-format.linux]

--- a/console_backend/src/types.rs
+++ b/console_backend/src/types.rs
@@ -1332,7 +1332,7 @@ mod tests {
             filename,
             /*close_when_done = */ true,
         );
-        sleep(Duration::from_millis(100));
+        sleep(Duration::from_millis(150));
         assert!(shared_state.is_running());
         sleep(Duration::from_secs_f64(SBP_FILE_SHORT_DURATION_SEC));
         assert!(!shared_state.is_running());


### PR DESCRIPTION
I believe this should catch the issue @silverjam saw; however, I'm not sure if retrying only 10s later will resolve it.

Also bumped up a timer for one of the "connect to file" unittests.