### PR TITLE
Add joining to increase reliability when closing[CPP-237].

### DIFF
--- a/console_backend/src/constants.rs
+++ b/console_backend/src/constants.rs
@@ -8,6 +8,10 @@ pub(crate) const APPLICATION_ORGANIZATION: &str = "swift-nav";
 pub(crate) const APPLICATION_NAME: &str = "swift_navigation_console";
 // CLI constants.
 
+// Server constants.
+#[allow(dead_code)]
+pub(crate) const FETCH_MESSAGE_TIMEOUT_MS: u64 = 1;
+
 // Process Message constants.
 pub(crate) const PAUSE_LOOP_SLEEP_DURATION_MS: u64 = 100;
 

--- a/console_backend/src/process_messages.rs
+++ b/console_backend/src/process_messages.rs
@@ -202,6 +202,7 @@ where
     }
     if conn.close_when_done() {
         shared_state.set_running(false, client_send.clone());
+        shared_state.stop_server_running();
         close_frontend(&mut client_send);
     }
     Ok(())


### PR DESCRIPTION
## Implements
* Added drop for Server and ServerEndpoint(might be unnecessary). ~Drop for Server attempts to join the main backend thread~
* Added a timeout to the fetch_message rust -> python function to prevent locking up on join initiated by the frontend.
* Adds an IS_RUNNING global to the Frontend receive_messages function thread in order to join after the app begins to close.
* Added a mutex and join when frontend begins to close the app.

## Concerns
* Not actual sure if this resolved the issue there is only so much manual testing I can do. But no failures after ~30-40 tries. Might be worth setting up a one off test rig which simulates hitting the close button and checking the return code.
* I set the timeout to 1 millisecond and it does burn cycles, might need to set this to just under whatever device max data rate is. I see on piksi 10-20kb/s not sure what the average SBP message size is but could calculate an optimal timeout in theory.