### PR TITLE
Fix the miniconda version used by the action in GA.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,7 @@ env:
   RUST_CACHE_DIRS: "~/.cargo/registry\n~/.cargo/git\ntarget\n"
   LIBCLANG_PATH_WIN: "C:/Program Files (x86)/Microsoft Visual Studio/2019/Enterprise/VC/Tools/Llvm/x64/bin"
   CARGO_MAKE_VERSION: 0.35.0
+  MINICONDA_VERSION: "py38_4.10.3"
 
 jobs:
 
@@ -88,6 +89,7 @@ jobs:
         with:
           activate-environment: console_pp
           environment-file: conda.yml
+          miniconda-version: ${{ env.MINICONDA_VERSION }}
 
       - name: Cache pip
         uses: actions/cache@v2
@@ -164,6 +166,7 @@ jobs:
         with:
           activate-environment: console_pp
           environment-file: conda.yml
+          miniconda-version: ${{ env.MINICONDA_VERSION }}
 
       - name: Run Requirements Generation Check
         run: |
@@ -281,6 +284,7 @@ jobs:
         with:
           activate-environment: console_pp
           environment-file: conda.yml
+          miniconda-version: ${{ env.MINICONDA_VERSION }}
 
       - name: Cache pip
         uses: actions/cache@v2

--- a/console_backend/benches/cpu_benches.rs
+++ b/console_backend/benches/cpu_benches.rs
@@ -28,10 +28,10 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     group.measurement_time(time::Duration::from_millis(BENCHMARK_TIME_LIMIT));
     group.sample_size(BENCHMARK_SAMPLE_SIZE);
     group.bench_function(BENCH_NAME_FAILURE, |b| {
-        b.iter(|| run_process_messages(&BENCH_FILEPATH, true))
+        b.iter(|| run_process_messages(BENCH_FILEPATH, true))
     });
     group.bench_function(BENCH_NAME_SUCCESS, |b| {
-        b.iter(|| run_process_messages(&BENCH_FILEPATH, false))
+        b.iter(|| run_process_messages(BENCH_FILEPATH, false))
     });
 }
 

--- a/console_backend/src/main_tab.rs
+++ b/console_backend/src/main_tab.rs
@@ -265,19 +265,16 @@ mod tests {
     use tempfile::TempDir;
 
     struct GpsTimeTests {
-        pub zero_week: i16,
         pub good_week: i16,
         pub early_gps_tow_good: f64,
         pub later_gps_tow_good: f64,
     }
     impl GpsTimeTests {
         fn new() -> GpsTimeTests {
-            let zero_week: i16 = 0;
             let good_week: i16 = 2000;
             let early_gps_tow_good: f64 = 5432.0;
             let later_gps_tow_good: f64 = 5433.0;
             GpsTimeTests {
-                zero_week,
                 good_week,
                 early_gps_tow_good,
                 later_gps_tow_good,


### PR DESCRIPTION
Fix miniconda version for the Github Actions we use.
Fix a few lint errors causing failures as well.