### PR TITLE
Console Log as Table.[CPP-117][CPP-279]

### DIFF
--- a/console_backend/src/connection.rs
+++ b/console_backend/src/connection.rs
@@ -228,6 +228,7 @@ impl ConnectionState {
     ) -> JoinHandle<()> {
         thread::spawn(move || {
             let mut conn = None;
+            info!("Console started...");
             while shared_state.clone().is_server_running() {
                 if let Ok(conn_option) = receiver.recv_timeout(Duration::from_secs_f64(
                     SERVER_STATE_CONNECTION_LOOP_TIMEOUT_SEC,
@@ -253,6 +254,7 @@ impl ConnectionState {
                     }
                     shared_state.set_running(false, client_send.clone());
                 }
+                log::logger().flush();
             }
         })
     }

--- a/console_backend/src/errors.rs
+++ b/console_backend/src/errors.rs
@@ -14,3 +14,4 @@ pub(crate) const TCP_CONNECTION_PARSING_FAILURE: &str =
     "unable to parse the provided string for ip string";
 pub(crate) const SERVER_STATE_NEW_CONNECTION_FAILURE: &str = "server state new connection failure";
 pub(crate) const SERVER_STATE_DISCONNECT_FAILURE: &str = "server state disconnect failure";
+pub(crate) const CONSOLE_LOG_JSON_TO_STRING_FAILURE: &str = "unable to convert json to string";

--- a/console_backend/src/piksi_tools_constants.rs
+++ b/console_backend/src/piksi_tools_constants.rs
@@ -508,7 +508,7 @@ pub const SMOOTHPOSE: i32 = 0;
 pub const DR_RUNNER: i32 = 1;
 lazy_static! {
     pub static ref ins_type_dict: HashMap<i32, &'static str> =
-        [(SMOOTHPOSE, "SP"), (DR_RUNNER, "DR")]
+        [(SMOOTHPOSE, "SP-"), (DR_RUNNER, "")]
             .iter()
             .cloned()
             .collect::<HashMap<_, _>>();

--- a/resources/Constants/Constants.qml
+++ b/resources/Constants/Constants.qml
@@ -13,6 +13,7 @@ QtObject {
     readonly property real logPanelPreferredHeight: 100
     readonly property real navBarPreferredHeight: 50
     readonly property real statusBarPreferredHeight: 30
+    property QtObject logPanel
     property QtObject statusBar
     property QtObject navBar
     property QtObject sideNavBar
@@ -60,11 +61,12 @@ QtObject {
     }
 
     genericTable: QtObject {
+        readonly property int headerZOffset: 100
         readonly property int padding: 2
         readonly property int mouseAreaResizeWidth: 10
         readonly property int cellHeight: 25
         readonly property string cellHighlightedColor: "crimson"
-        readonly property string cellColor: "ghostwhite"
+        readonly property string cellColor: "white"
         readonly property string gradientColor: "gainsboro"
         readonly property string borderColor: "gainsboro"
         readonly property string fontFamily: "Roboto"
@@ -235,6 +237,16 @@ QtObject {
         readonly property string xAxisTitleText: "Longitude"
         readonly property var legendLabels: ["SPP", "DGPS", "RTK Float", "RTK Fixed", "DR", "SBAS"]
         readonly property var colors: ["#0000FF", "#00B3FF", "#BF00BF", "#FFA500", "#000000", "#00FF00"]
+    }
+
+    logPanel: QtObject {
+        readonly property int width: 220
+        readonly property variant defaultColumnWidthRatios: [0.15, 0.1, 0.75]
+        readonly property int maxRows: 200
+        readonly property int cellHeight: 20
+        readonly property string timestampHeader: "Host Timestamp"
+        readonly property string levelHeader: "Log Level"
+        readonly property string msgHeader: "Message"
     }
 
     solutionTable: QtObject {

--- a/resources/LogPanel.qml
+++ b/resources/LogPanel.qml
@@ -1,40 +1,230 @@
 import "./Constants"
-import QtQuick 2.14
+import Qt.labs.qmlmodels 1.0
+import QtCharts 2.2
+import QtQuick 2.15
 import QtQuick.Controls 2.15
-import QtQuick.Layouts 1.15
 import SwiftConsole 1.0
 
-Rectangle {
+Item {
+    property var logEntries: []
+    property variant columnWidths: [parent.width * Constants.logPanel.defaultColumnWidthRatios[0], parent.width * Constants.logPanel.defaultColumnWidthRatios[1], parent.width * Constants.logPanel.defaultColumnWidthRatios[2]]
+    property real mouse_x: 0
+    property int selectedRow: -1
+    property bool forceLayoutLock: false
+
+    function syncColumnWidths() {
+        let column_width_sum = columnWidths[0] + columnWidths[1] + columnWidths[2];
+        if (column_width_sum != tableView.width) {
+            let final_column_diff = tableView.width - column_width_sum;
+            columnWidths[2] += final_column_diff;
+        }
+        tableView.forceLayout();
+    }
+
+    width: parent.width
+    height: parent.height
+
     LogPanelData {
         id: logPanelData
     }
 
-    Text {
-        id: innerText
+    Rectangle {
+        anchors.fill: parent
 
-        text: ""
-        font.pointSize: Constants.largePointSize
-        padding: 5
-    }
+        TextEdit {
+            id: textEdit
 
-    Timer {
-        interval: Globals.currentRefreshRate
-        running: true
-        repeat: true
-        onTriggered: {
-            if (innerText.text.length > 32000) {
-                innerText.text = "Overflowed";
-                logPanelData.entries = [];
-                return ;
-            }
-            log_panel_model.fill_data(logPanelData);
-            let newText = '';
-            for (const entry of logPanelData.entries) {
-                newText = entry + '\n' + newText;
-            }
-            logPanelData.entries = [];
-            innerText.text = newText + innerText.text;
+            visible: false
         }
+
+        Shortcut {
+            sequence: StandardKey.Copy
+            onActivated: {
+                if (selectedRow != -1) {
+                    textEdit.text = JSON.stringify(tableView.model.getRow(selectedRow));
+                    textEdit.selectAll();
+                    textEdit.copy();
+                    selectedRow = -1;
+                }
+            }
+        }
+
+        HorizontalHeaderView {
+            id: horizontalHeader
+
+            interactive: false
+            syncView: tableView
+            anchors.top: parent.top
+            z: Constants.genericTable.headerZOffset
+
+            delegate: Rectangle {
+                implicitWidth: columnWidths[index]
+                implicitHeight: Constants.genericTable.cellHeight
+                border.color: Constants.genericTable.borderColor
+
+                Text {
+                    width: parent.width
+                    anchors.centerIn: parent
+                    horizontalAlignment: Text.AlignHCenter
+                    verticalAlignment: Text.AlignVCenter
+                    text: tableView.model.columns[index].display
+                    elide: Text.ElideRight
+                    clip: true
+                    font.family: Constants.genericTable.fontFamily
+                }
+
+                MouseArea {
+                    width: Constants.genericTable.mouseAreaResizeWidth
+                    height: parent.height
+                    anchors.right: parent.right
+                    cursorShape: Qt.SizeHorCursor
+                    onPressed: {
+                        mouse_x = mouseX;
+                        forceLayoutLock = true;
+                    }
+                    onPositionChanged: {
+                        if (pressed) {
+                            if (index == 2)
+                                return ;
+
+                            var delta_x = (mouseX - mouse_x);
+                            columnWidths[index] += delta_x;
+                            syncColumnWidths();
+                        }
+                    }
+                    onReleased: {
+                        forceLayoutLock = false;
+                    }
+                }
+
+                gradient: Gradient {
+                    GradientStop {
+                        position: 0
+                        color: Constants.genericTable.cellColor
+                    }
+
+                    GradientStop {
+                        position: 1
+                        color: Constants.genericTable.gradientColor
+                    }
+
+                }
+
+            }
+
+        }
+
+        TableView {
+            id: tableView
+
+            columnSpacing: -1
+            rowSpacing: -1
+            columnWidthProvider: function(column) {
+                return columnWidths[column];
+            }
+            reuseItems: true
+            boundsBehavior: Flickable.StopAtBounds
+            anchors.top: horizontalHeader.bottom
+            width: parent.width
+            height: parent.height - horizontalHeader.height
+
+            ScrollBar.horizontal: ScrollBar {
+            }
+
+            ScrollBar.vertical: ScrollBar {
+            }
+
+            model: TableModel {
+                id: tableModel
+
+                Component.onCompleted: {
+                    let row_init = {
+                    };
+                    row_init[Constants.logPanel.timestampHeader] = "";
+                    row_init[Constants.logPanel.levelHeader] = "";
+                    row_init[Constants.logPanel.msgHeader] = "";
+                    tableView.model.setRow(0, row_init);
+                }
+                rows: []
+
+                TableModelColumn {
+                    display: Constants.logPanel.timestampHeader
+                }
+
+                TableModelColumn {
+                    display: Constants.logPanel.levelHeader
+                }
+
+                TableModelColumn {
+                    display: Constants.logPanel.msgHeader
+                }
+
+            }
+
+            delegate: Rectangle {
+                implicitHeight: Constants.logPanel.cellHeight
+                implicitWidth: tableView.columnWidthProvider(column)
+                color: row == selectedRow ? Constants.genericTable.cellHighlightedColor : Constants.genericTable.cellColor
+
+                Text {
+                    width: parent.width
+                    horizontalAlignment: Text.AlignLeft
+                    clip: true
+                    font.family: Constants.genericTable.fontFamily
+                    font.pointSize: Constants.largePointSize
+                    text: model.display
+                    elide: Text.ElideRight
+                    padding: Constants.genericTable.padding
+                }
+
+                MouseArea {
+                    width: parent.width
+                    height: parent.height
+                    anchors.centerIn: parent
+                    onPressed: {
+                        if (selectedRow == row)
+                            selectedRow = -1;
+                        else
+                            selectedRow = row;
+                    }
+                }
+
+            }
+
+        }
+
+        Timer {
+            interval: Globals.currentRefreshRate
+            running: true
+            repeat: true
+            onTriggered: {
+                log_panel_model.fill_data(logPanelData);
+                if (!logPanelData.entries.length)
+                    return ;
+
+                if (forceLayoutLock)
+                    return ;
+
+                for (var idx in logPanelData.entries) {
+                    var new_row = {
+                    };
+                    new_row[Constants.logPanel.timestampHeader] = logPanelData.entries[idx].timestamp;
+                    new_row[Constants.logPanel.levelHeader] = logPanelData.entries[idx].level;
+                    new_row[Constants.logPanel.msgHeader] = logPanelData.entries[idx].msg;
+                    logEntries.unshift(new_row);
+                }
+                logEntries = logEntries.slice(0, Constants.logPanel.maxRows);
+                for (var idx in logEntries) {
+                    tableView.model.setRow(idx, logEntries[idx]);
+                }
+                if (logPanelData.entries.length && selectedRow != -1)
+                    selectedRow += logPanelData.entries.length;
+
+                logPanelData.entries = [];
+                tableView.forceLayout();
+            }
+        }
+
     }
 
 }

--- a/resources/SolutionTabComponents/SolutionTable.qml
+++ b/resources/SolutionTabComponents/SolutionTable.qml
@@ -1,6 +1,5 @@
 import "../Constants"
 import Qt.labs.qmlmodels 1.0
-import Qt.labs.qmlmodels 1.0
 import QtCharts 2.2
 import QtQuick 2.15
 import QtQuick.Controls 2.15
@@ -49,6 +48,7 @@ Item {
 
                 interactive: false
                 syncView: tableView
+                z: Constants.genericTable.headerZOffset
 
                 delegate: Rectangle {
                     implicitWidth: columnWidths[index]

--- a/resources/view.qml
+++ b/resources/view.qml
@@ -60,15 +60,9 @@ ApplicationWindow {
                     Layout.rightMargin: Constants.margins
                 }
 
-                Rectangle {
-                    id: consoleLog
-
+                LogPanel {
                     SplitView.fillWidth: true
                     SplitView.preferredHeight: Constants.logPanelPreferredHeight
-
-                    LogPanel {
-                    }
-
                 }
 
             }

--- a/src/main/python/log_panel.py
+++ b/src/main/python/log_panel.py
@@ -1,5 +1,7 @@
-"""Nav Bar QObjects.
+"""Log Panel QObjects.
 """
+
+import json
 
 from typing import Dict, List, Any
 
@@ -15,19 +17,19 @@ log_panel_lock = QMutex()
 
 
 class LogPanelData(QObject):
-    _entries: List[str] = []
+    _entries: List[Dict[str, str]] = []
 
-    def get_entries(self) -> List[str]:
+    def get_entries(self) -> List[Dict[str, str]]:
         """Getter for _entries."""
         return self._entries
 
-    def set_entries(self, entries: List[str]) -> None:
+    def set_entries(self, entries: List[Dict[str, str]]) -> None:
         """Setter for _entries."""
         self._entries = entries
 
     entries = Property(QTKeys.QVARIANTLIST, get_entries, set_entries)  # type: ignore
 
-    def append_entries(self, entries: List[str]) -> None:
+    def append_entries(self, entries: List[Dict[str, str]]) -> None:
         self._entries += entries
 
 
@@ -37,7 +39,10 @@ class LogPanelModel(QObject):  # pylint: disable=too-few-public-methods
         # Avoid locking so that message processor has priority to lock
         if LOG_PANEL[Keys.ENTRIES]:
             if log_panel_lock.try_lock():
-                cp.append_entries(LOG_PANEL[Keys.ENTRIES])
+                entries = []
+                for entry in LOG_PANEL[Keys.ENTRIES]:
+                    entries.append(json.loads(entry))
+                cp.append_entries(entries)
                 LOG_PANEL[Keys.ENTRIES][:] = []
                 log_panel_lock.unlock()
         return cp


### PR DESCRIPTION
* Converted existing console log to table.
* Made log messages available outside of process_messages.
* Moved receive backend thread outside of Server.start function (seems logging does not work inside? possibly due to it being a pymethod)
* Threw the setup logging in Server.start into a function in log_panel.rs.
* Converted logging messages into json before sending over to frontend to be decoded into timestamp / log level / message for table.
* Fixed issue with table header not always being above table when scrolling up/down.
* Changed background color of console log / solution table to be white to blend better with app color scheme.
* Removed TODO for CPP-117 it looks like the MsgLog does not contain a remote timestamp and log level is correctly filtered now between device/console logs.