### PR TITLE
add fileio alias

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -9,3 +9,6 @@ rustflags = [
   "-C", "link-arg=-undefined",
   "-C", "link-arg=dynamic_lookup",
 ]
+
+[alias]
+fileio = "run --bin fileio --no-default-features --"


### PR DESCRIPTION
So you can just run `cargo fileio ...` from anywhere in the workspace