### PR TITLE
Minor Rust build improvements.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,4 +4,3 @@ members = ["console_backend"]
 [profile.release]
 lto = true
 codegen-units = 1
-opt-level = "z"


### PR DESCRIPTION
Three suggestions for speeding up CI from this article:
https://matklad.github.io/2021/09/04/fast-rust-builds.html

* Disable incremental builds.
* Disable debug info.
* Use a different Rust cache action specifically tailored for Rust.

Results:
Consider a pass as a new commit to the PR triggering a rebuild.
* In terms of first run of a new PR it appears to be the same as our current CI give or take:
    - Old build (first pass): Total Duration: ~57m, Total Billable: ~2hr20m
    - New build (first pass): Total Duration:  ~57m, Total Billable ~2hr15m
* In terms of second or more pass through a PR:
    - Old build (2+ pass): Total Duration: ~55m, Total Billable: ~2hr7m
    - New build (2+ pass): Total Duration: ~40m, Total Billable: ~1hr30m

Shows a large improvement on second plus passes through PRs. 