### PR TITLE
Remove unnecessary additional logging from headless runner.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -379,7 +379,6 @@ dependencies = [
  "serial_test",
  "serialport",
  "slotmap",
- "snap",
  "strum",
  "strum_macros",
  "sysinfo",
@@ -1702,12 +1701,6 @@ name = "smallvec"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
-
-[[package]]
-name = "snap"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45456094d1983e2ee2a18fdfebce3189fa451699d0502cb8e3b49dba5ba41451"
 
 [[package]]
 name = "spin"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -158,8 +158,7 @@ args = [
   "run",
   "--bin",
   "headless-console",
-  "--features",
-  "headless-console",
+  "--release",
   "--no-default-features",
   "${@}",
 ]

--- a/console_backend/Cargo.toml
+++ b/console_backend/Cargo.toml
@@ -40,7 +40,6 @@ minreq = { version = "2.4.2", features = ["https"] }
 regex = { version = "1.5.4" }
 semver = { version = "1" }
 rust-ini = "0.17.0"
-snap = { version = "1", optional = true }
 
 [dependencies.sbp]
 git = "https://github.com/swift-nav/libsbp.git"
@@ -85,11 +84,9 @@ required-features = ["fft"]
 name = "headless-console"
 path = "src/bin/headless-console.rs"
 bench = false
-required-features = ["headless-console"]
 
 [features]
 default = ["pyo3"]
 benches = []
 tests = []
 fft = ["serde-pickle"]
-headless-console = ["snap"]


### PR DESCRIPTION
This logging is unnecessary and worse than just standard sbp logging.