### PR TITLE
Add Hint for Building on macos

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ cargo make pip-install-dev
 git lfs pull
 ```
 
-# Building for macos
+# Troubleshooting building for macos
 
 The module used for generating rust bindings for native libraries; `rust-bindgen` 
 has been observed to fail to find system headers (i.e. `assert.h`, `math.h`) on 


### PR DESCRIPTION
The way rust-bindgen builds header search paths is not particularly
robust on macos. This adds instructions for passing extra search
paths to clang during bindgen. Also modifies the macos instructions
to prefer the system install of clang to homebrew clang.