### PR TITLE
Bump up backend mem bench thresholds wrt mimalloc variance.

### DIFF
--- a/console_backend/tests/mem_benches.rs
+++ b/console_backend/tests/mem_benches.rs
@@ -21,10 +21,10 @@ mod mem_bench_impl {
     const BENCH_FILEPATH: &str = "./tests/data/piksi-relay-1min.sbp";
     const MINIMUM_MEM_READINGS: usize = 20;
 
-    const DIFF_THRESHOLD: f32 = 0.05;
+    const DIFF_THRESHOLD: f32 = 0.1;
     const MAXIMUM_MEM_USAGE_KB: f32 = 220000.0;
     const ABSOLUTE_MINIMUM_MEM_USAGE: f32 = 1000.0;
-    const MAXIMUM_STANDARD_DEV_RATE_OF_MAXIMUM_MEM: f32 = 0.4;
+    const MAXIMUM_STANDARD_DEV_RATE_OF_MAXIMUM_MEM: f32 = 0.5;
 
     /// Convert a 1D Vector to an ArrayView.
     ///


### PR DESCRIPTION
Bump up the difference threshold and the maximum std dev percentage.

We may need to rework how this benchmark is done. I suspect most of the variance occurs when the console is first executed which may be quite different from the steady state memory usage making this less useful than informative.