### PR TITLE
[CPP-346] Remove check for downgrade

### DIFF
--- a/console_backend/src/update_tab.rs
+++ b/console_backend/src/update_tab.rs
@@ -443,22 +443,7 @@ fn upgrade_firmware(
     update_tab_context.set_upgrading(true);
     update_tab_context.fw_log_clear();
     let to_upgrade = match check_above_v2(update_tab_context.clone()) {
-        Ok(above_v2) => {
-            if !above_v2 {
-                true
-            } else {
-                match check_firmware_outdated(update_tab_context.clone()) {
-                    Ok(outdated) => outdated,
-                    Err(err) => {
-                        update_tab_context.fw_log_append(String::from(
-                            "Unable to compare latest and current version.",
-                        ));
-                        update_tab_context.fw_log_append(err.to_string());
-                        false
-                    }
-                }
-            }
-        }
+        Ok(_) => true,
         Err(_) => {
             update_tab_context.fw_log_append(String::from(
                 "Waiting on settings to load to get current version.",


### PR DESCRIPTION
Removes the gate on checking whether the latest firmware version is
older than the current version, to allow users to upgrade and downgrade
as they please.