### PR TITLE
Format Corr Age in Status Bar [CPP-289]

### DIFF
--- a/console_backend/src/status_bar.rs
+++ b/console_backend/src/status_bar.rs
@@ -461,7 +461,7 @@ impl HeartbeatInner {
             if let Some(last_age_corr_time) = self.last_age_corr_receipt_time {
                 if (self.current_time - last_age_corr_time).as_secs_f64() < UPDATE_TOLERANCE_SECONDS
                 {
-                    self.age_of_corrections = format!("{} s", age_corr);
+                    self.age_of_corrections = format!("{:.1} s", age_corr);
                 }
             }
         }


### PR DESCRIPTION
The corr age property in the status bar has been updated to
always show 1 decimal point of precision so that the INS status
does not jump around when it is a whole number.