### PR TITLE
make: port constants tasks to duckscript

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -91,17 +91,20 @@ command = "cargo"
 args = ["install-update", "taplo-cli", "cargo-make"]
 
 [tasks.generate-common-constants-rs]
-script_runner = "@shell"
+script_runner = "@duckscript"
 script = '''
-${PYTHON} -m py2many --rust=1 swiftnav_console/constants.py
+python = get_env PYTHON
+exec ${python} -m py2many --rust=1 swiftnav_console/constants.py
 mv swiftnav_console/constants.rs console_backend/src/common_constants.rs
 '''
 
 [tasks.extract-piksi-constants-rs]
-script_runner = "@shell"
+script_runner = "@duckscript"
 script = '''
-${PYTHON} utils/extract_piksi_tools_constants.py > /tmp/piksi_tools_constants.py
-${PYTHON} -m py2many --rust=1 /tmp/piksi_tools_constants.py --outdir console_backend/src/
+python = get_env PYTHON
+output = exec --fail-on-error ${python} utils/extract_piksi_tools_constants.py
+writefile /tmp/piksi_tools_constants.py ${output.stdout}
+exec --fail-on-error ${python} -m py2many --rust=1 /tmp/piksi_tools_constants.py --outdir console_backend/src/
 '''
 
 [tasks.generate-resources]


### PR DESCRIPTION
Fixes a build error that @keithel-qt was seeing, briefly tested the `generate-common-constants-rs` task to see if it actually updated things, and it did:

```
diff --git a/console_backend/src/common_constants.rs b/console_backend/src/common_constants.rs
index 04884b5..f6732f2 100644
--- a/console_backend/src/common_constants.rs
+++ b/console_backend/src/common_constants.rs
@@ -29,7 +29,7 @@ use strum_macros::{Display, EnumString, EnumVariantNames};
 
 #[derive(Clone, Debug, Display, EnumString, EnumVariantNames, Eq, Hash, PartialEq)]
 pub enum Tabs {
-    #[strum(serialize = "TRACKING_SIGNALS")]
+    #[strum(serialize = "TRACKING_SIGNALS2")]
     TRACKING_SIGNALS,
     #[strum(serialize = "TRACKING_SKYPLOT")]
     TRACKING_SKYPLOT,
diff --git a/swiftnav_console/constants.py b/swiftnav_console/constants.py
index 0491de0..98caefc 100644
--- a/swiftnav_console/constants.py
+++ b/swiftnav_console/constants.py
@@ -2,7 +2,7 @@ from enum import Enum
 
 
 class Tabs(str, Enum):
-    TRACKING_SIGNALS = "TRACKING_SIGNALS"
+    TRACKING_SIGNALS = "TRACKING_SIGNALS2"
     TRACKING_SKYPLOT = "TRACKING_SKYPLOT"
     SOLUTION_POSITION = "SOLUTION_POSITION"
     SOLUTION_VELOCITY = "SOLUTION_VELOCITY"
```

The extract* task does at least generate a file in `/tmp`:

```
❯ cargo make extract-piksi-constants-rs
[cargo-make] INFO - cargo make 0.35.1
[cargo-make] INFO - Build File: Makefile.toml
[cargo-make] INFO - Task: extract-piksi-constants-rs
[cargo-make] INFO - Profile: development
[cargo-make] INFO - Running Task: legacy-migration
[cargo-make] INFO - Running Task: extract-piksi-constants-rs
Writing to: console_backend/src
/tmp/piksi_tools_constants.py ... console_backend/src/piksi_tools_constants.rs
[cargo-make] INFO - Build Done in 0.77 seconds.

❯ cat /tmp/piksi_tools_constants.py | wc -l
579

❯ ls -lsh /tmp/piksi_tools_constants.py 
12K -rw-r--r-- 1 jmob jmob 12K Oct 26 10:16 /tmp/piksi_tools_constants.py
```