### PR TITLE
add validator to settings text field [CPP-388]

### DIFF
--- a/resources/SettingsTab.qml
+++ b/resources/SettingsTab.qml
@@ -12,6 +12,10 @@ import SwiftConsole 1.0
 Item {
     id: settingsTab
 
+    property var floatValidator
+    property var intValidator
+    property var stringValidator
+
     function selectedRow() {
         var rowIdx = settingsTable.selectedRow;
         if (rowIdx < 0)
@@ -287,6 +291,7 @@ Item {
                         // the onDestruction event has triggered
                         property string settingGroup: selectedRowField("group")
                         property string settingName: selectedRowField("name")
+                        property string settingType: selectedRowField("type")
 
                         text: selectedRowField(_fieldName)
                         wrapMode: Text.WordWrap
@@ -297,6 +302,14 @@ Item {
                         }
                         Component.onDestruction: {
                             data_model.settings_write_request(settingGroup, settingName, text);
+                        }
+                        validator: {
+                            if (settingType === "integer")
+                                return intValidator;
+                            else if (settingType === "float" || settingType === "double")
+                                return floatValidator;
+                            else
+                                return stringValidator;
                         }
                     }
 
@@ -420,6 +433,15 @@ Item {
 
         }
 
+    }
+
+    floatValidator: DoubleValidator {
+    }
+
+    intValidator: IntValidator {
+    }
+
+    stringValidator: RegExpValidator {
     }
 
 }


### PR DESCRIPTION
Originally attempted to build something that checked if the input was valid, and if it wasn't it changed the highlight color from orange to red. Then I realized they had built in validators... These ones work differently though, they just don't let you type in invalid text at all. So if its an int field and you type letters they just don't register as key presses. 