### PR TITLE
Fixes baseline plot railing to inf.[CPP-271]

### DIFF
--- a/resources/BaselineTabComponents/BaselinePlot.qml
+++ b/resources/BaselineTabComponents/BaselinePlot.qml
@@ -397,11 +397,36 @@ Item {
                         if (center_solution)
                             baselinePlotChart.centerToSolution();
 
-                        if (orig_n_min != baselinePlotPoints.n_min || orig_n_max != baselinePlotPoints.n_max || orig_e_min != baselinePlotPoints.e_min || orig_e_max != baselinePlotPoints.e_max) {
-                            orig_n_min = baselinePlotPoints.n_min;
-                            orig_n_max = baselinePlotPoints.n_max;
-                            orig_e_min = baselinePlotPoints.e_min;
-                            orig_e_max = baselinePlotPoints.e_max;
+                        let hasData = false;
+                        for (let idx in baselinePlotPoints.points) {
+                            if (baselinePlotPoints.points[idx].length > 0) {
+                                hasData = true;
+                                break;
+                            }
+                        }
+                        let new_n_min = Constants.baselinePlot.axesDefaultMin;
+                        let new_n_max = Constants.baselinePlot.axesDefaultMax;
+                        let new_e_min = Constants.baselinePlot.axesDefaultMin;
+                        let new_e_max = Constants.baselinePlot.axesDefaultMax;
+                        baselineZoomAllButton.enabled = hasData;
+                        baselineCenterButton.enabled = hasData;
+                        if (hasData) {
+                            new_n_min = baselinePlotPoints.n_min;
+                            new_n_max = baselinePlotPoints.n_max;
+                            new_e_min = baselinePlotPoints.e_min;
+                            new_e_max = baselinePlotPoints.e_max;
+                        } else {
+                            zoom_all = true;
+                            center_solution = false;
+                            baselineZoomAllButton.checked = true;
+                            baselineCenterButton.checked = false;
+                            baselinePlotChart.resetChartZoom();
+                        }
+                        if (orig_n_min != new_n_min || orig_n_max != new_n_max || orig_e_min != new_e_min || orig_e_max != new_e_max) {
+                            orig_n_min = new_n_min;
+                            orig_n_max = new_n_max;
+                            orig_e_min = new_e_min;
+                            orig_e_max = new_e_max;
                             if (zoom_all)
                                 baselinePlotChart.resetChartZoom();
 

--- a/resources/Constants/Constants.qml
+++ b/resources/Constants/Constants.qml
@@ -331,6 +331,8 @@ QtObject {
         readonly property int navBarSpacing: 0
         readonly property real navBarButtonWidth: 40
         readonly property real resetFiltersButtonWidth: 100
+        readonly property int axesDefaultMin: 0
+        readonly property int axesDefaultMax: 1
         readonly property string yAxisTitleText: "N (meters)"
         readonly property string xAxisTitleText: "E (meters)"
         readonly property var legendLabels: ["Base Position", "DGPS", "RTK Float", "RTK Fixed"]


### PR DESCRIPTION
This prevents the baseline plot axes from railing to inf when switching between piksi that does and does not have data to display for the baseline plot. E.g. piksi relay vs 10.1.54.1/2 .

The new behavior is to fix the axes to 0->1 for N and E when no data is populated. Assuming at the 0/0 point there is a marker for the "Base Position"

https://user-images.githubusercontent.com/43353147/138943236-10946c36-7e0b-4241-a8e5-0e0835fc9c66.mp4

. 