### PR TITLE
box client sender

### DIFF
--- a/console_backend/benches/cpu_benches.rs
+++ b/console_backend/benches/cpu_benches.rs
@@ -12,11 +12,12 @@ use std::{
 
 extern crate console_backend;
 use console_backend::{
+    client_sender::ChannelSender,
     common_constants::ConnectionState,
     connection::{Connection, ConnectionManager},
     process_messages,
     shared_state::SharedState,
-    types::{ClientSender, RealtimeDelay},
+    types::RealtimeDelay,
 };
 
 const BENCH_FILEPATH: &str = "./tests/data/piksi-relay.sbp";
@@ -53,7 +54,7 @@ fn run_process_messages(file_in_name: &str, failure: bool) {
     });
     {
         let (client_send, client_recv) = channel::unbounded::<Vec<u8>>();
-        let client_send = ClientSender::new(client_send);
+        let client_send = ChannelSender::boxed(client_send);
         client_recv_tx
             .send(client_recv)
             .expect("sending client recv handle should succeed");

--- a/console_backend/src/advanced_magnetometer_tab.rs
+++ b/console_backend/src/advanced_magnetometer_tab.rs
@@ -2,9 +2,10 @@ use sbp::messages::mag::MsgMagRaw;
 
 use capnp::message::Builder;
 
+use crate::client_sender::BoxedClientSender;
 use crate::constants::{MAGNETOMETER_Y_AXIS_PADDING_MULTIPLIER, NUM_POINTS};
 use crate::shared_state::SharedState;
-use crate::types::{CapnProtoSender, Deque};
+use crate::types::Deque;
 use crate::utils::serialize_capnproto_builder;
 use crate::zip;
 
@@ -19,8 +20,8 @@ use crate::zip;
 /// - `mag_z`: The stored historic Magnetometer values along z axis.
 /// - `shared_state`: The shared state for communicating between frontend/backend/other backend tabs.
 #[derive(Debug)]
-pub struct AdvancedMagnetometerTab<S: CapnProtoSender> {
-    client_sender: S,
+pub struct AdvancedMagnetometerTab {
+    client_sender: BoxedClientSender,
     mag_x: Deque<f64>,
     mag_y: Deque<f64>,
     mag_z: Deque<f64>,
@@ -29,8 +30,11 @@ pub struct AdvancedMagnetometerTab<S: CapnProtoSender> {
     ymin: f64,
 }
 
-impl<S: CapnProtoSender> AdvancedMagnetometerTab<S> {
-    pub fn new(shared_state: SharedState, client_sender: S) -> AdvancedMagnetometerTab<S> {
+impl AdvancedMagnetometerTab {
+    pub fn new(
+        shared_state: SharedState,
+        client_sender: BoxedClientSender,
+    ) -> AdvancedMagnetometerTab {
         AdvancedMagnetometerTab {
             client_sender,
             mag_x: Deque::with_fill_value(NUM_POINTS, 0.),
@@ -96,12 +100,12 @@ impl<S: CapnProtoSender> AdvancedMagnetometerTab<S> {
 mod tests {
 
     use super::*;
-    use crate::types::TestSender;
+    use crate::client_sender::TestSender;
 
     #[test]
     fn hangle_mag_raw_test() {
         let shared_state = SharedState::new();
-        let client_send = TestSender { inner: Vec::new() };
+        let client_send = TestSender::boxed();
         let mut mag_tab = AdvancedMagnetometerTab::new(shared_state, client_send);
         let tow = 1_u32;
         let tow_f = 1_u8;
@@ -130,7 +134,7 @@ mod tests {
     #[test]
     fn handle_imu_send_data_test() {
         let shared_state = SharedState::new();
-        let client_send = TestSender { inner: Vec::new() };
+        let client_send = TestSender::boxed();
         let mut mag_tab = AdvancedMagnetometerTab::new(shared_state, client_send);
         assert!(f64::abs(mag_tab.ymin - f64::MAX) <= f64::EPSILON);
         assert!(f64::abs(mag_tab.ymax - f64::MIN) <= f64::EPSILON);

--- a/console_backend/src/bin/headless-console.rs
+++ b/console_backend/src/bin/headless-console.rs
@@ -2,11 +2,11 @@ use anyhow::Result;
 use chrono::prelude::*;
 use console_backend::{
     cli_options::{handle_cli, CliOptions},
+    client_sender::ChannelSender,
     connection::ConnectionManager,
     log_panel::setup_logging,
     server_recv_thread::server_recv_thread,
     shared_state::SharedState,
-    types::ClientSender,
     utils::{refresh_connection_frontend, refresh_loggingbar},
 };
 use crossbeam::channel;
@@ -27,7 +27,7 @@ Usage:
     }
     let (client_send_, client_recv) = channel::unbounded::<Vec<u8>>();
     let (_server_send, server_recv) = channel::unbounded::<Vec<u8>>();
-    let client_send = ClientSender::new(client_send_);
+    let client_send = ChannelSender::boxed(client_send_);
     let shared_state = SharedState::new();
     setup_logging(client_send.clone(), shared_state.clone());
     let conn_manager = ConnectionManager::new(client_send.clone(), shared_state.clone());

--- a/console_backend/src/client_sender.rs
+++ b/console_backend/src/client_sender.rs
@@ -1,0 +1,107 @@
+use std::fmt;
+
+use crossbeam::channel::Sender;
+
+use crate::types::ArcBool;
+
+pub type BoxedClientSender = Box<dyn ClientSender + 'static>;
+
+pub trait ClientSender: ClientSenderClone {
+    fn send_data(&mut self, msg_bytes: Vec<u8>);
+    fn connected(&self) -> bool;
+    fn set_connected(&self, connected: bool);
+}
+
+// enables trait object safe cloning
+pub trait ClientSenderClone: fmt::Debug + Send + Sync {
+    fn clone_box(&self) -> BoxedClientSender;
+}
+
+impl<T> ClientSenderClone for T
+where
+    T: ClientSender + Clone + 'static,
+{
+    fn clone_box(&self) -> BoxedClientSender {
+        Box::new(self.clone())
+    }
+}
+
+impl Clone for BoxedClientSender {
+    fn clone(&self) -> BoxedClientSender {
+        self.clone_box()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ChannelSender {
+    inner: Sender<Vec<u8>>,
+    connected: ArcBool,
+}
+
+impl ChannelSender {
+    pub fn new(inner: Sender<Vec<u8>>) -> Self {
+        Self {
+            inner,
+            connected: ArcBool::new_with(true),
+        }
+    }
+
+    pub fn boxed(inner: Sender<Vec<u8>>) -> BoxedClientSender {
+        Box::new(Self::new(inner))
+    }
+}
+
+impl ClientSender for ChannelSender {
+    fn send_data(&mut self, msg_bytes: Vec<u8>) {
+        if self.connected.get() {
+            let _ = self.inner.send(msg_bytes);
+        }
+    }
+
+    fn connected(&self) -> bool {
+        self.connected.get()
+    }
+
+    fn set_connected(&self, connected: bool) {
+        self.connected.set(connected);
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TestSender {
+    inner: Vec<Vec<u8>>,
+    connected: ArcBool,
+}
+
+impl TestSender {
+    pub fn new() -> Self {
+        Self {
+            inner: Vec::new(),
+            connected: ArcBool::new_with(true),
+        }
+    }
+
+    pub fn boxed() -> BoxedClientSender {
+        Box::new(Self::new())
+    }
+}
+
+impl Default for TestSender {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ClientSender for TestSender {
+    fn send_data(&mut self, msg: Vec<u8>) {
+        self.inner.push(msg)
+    }
+
+    fn connected(&self) -> bool {
+        self.connected.get()
+    }
+
+    fn set_connected(&self, connected: bool) {
+        self.connected.set(connected);
+    }
+}

--- a/console_backend/src/fusion_status_flags.rs
+++ b/console_backend/src/fusion_status_flags.rs
@@ -9,13 +9,14 @@ use std::{
     time::Duration,
 };
 
+use crate::client_sender::BoxedClientSender;
 use crate::common_constants as cc;
 use crate::errors::{
     THREAD_JOIN_FAILURE, UNABLE_TO_SEND_INS_UPDATE_FAILURE, UNABLE_TO_STOP_TIMER_THREAD_FAILURE,
     UPDATE_STATUS_LOCK_MUTEX_FAILURE,
 };
 use crate::shared_state::SharedState;
-use crate::types::{ArcBool, CapnProtoSender};
+use crate::types::ArcBool;
 use crate::utils::serialize_capnproto_builder;
 
 const STATUS_PERIOD: f64 = 1.0;
@@ -268,8 +269,8 @@ impl Drop for FusionStatusFlag {
 /// - `nhc`: Storage for the non-holonomic constraints model status.
 /// - `zerovel`: Storage for the zero velocity status.
 #[derive(Debug)]
-pub struct FusionStatusFlags<S: CapnProtoSender> {
-    client_sender: S,
+pub struct FusionStatusFlags {
+    client_sender: BoxedClientSender,
     shared_state: SharedState,
     gnsspos: FusionStatusFlag,
     gnssvel: FusionStatusFlag,
@@ -279,8 +280,8 @@ pub struct FusionStatusFlags<S: CapnProtoSender> {
     zerovel: FusionStatusFlag,
 }
 
-impl<S: CapnProtoSender> FusionStatusFlags<S> {
-    pub fn new(shared_state: SharedState, client_sender: S) -> FusionStatusFlags<S> {
+impl FusionStatusFlags {
+    pub fn new(shared_state: SharedState, client_sender: BoxedClientSender) -> FusionStatusFlags {
         FusionStatusFlags {
             client_sender,
             shared_state,

--- a/console_backend/src/lib.rs
+++ b/console_backend/src/lib.rs
@@ -9,6 +9,7 @@ pub mod console_backend_capnp {
     include!(concat!(env!("OUT_DIR"), "/console_backend_capnp.rs"));
 }
 pub mod broadcaster;
+pub mod client_sender;
 pub mod common_constants;
 pub mod connection;
 pub mod constants;
@@ -58,27 +59,27 @@ use crate::{
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
-struct Tabs<S: types::CapnProtoSender> {
-    pub main: Mutex<MainTab<S>>,
-    pub advanced_imu: Mutex<AdvancedImuTab<S>>,
-    pub advanced_magnetometer: Mutex<AdvancedMagnetometerTab<S>>,
-    pub advanced_networking: Mutex<AdvancedNetworkingTab<S>>,
-    pub advanced_system_monitor: Mutex<AdvancedSystemMonitorTab<S>>,
-    pub baseline: Mutex<BaselineTab<S>>,
-    pub tracking_signals: Mutex<TrackingSignalsTab<S>>,
-    pub tracking_sky_plot: Mutex<TrackingSkyPlotTab<S>>,
-    pub solution: Mutex<SolutionTab<S>>,
-    pub observation: Mutex<ObservationTab<S>>,
-    pub solution_velocity: Mutex<SolutionVelocityTab<S>>,
-    pub advanced_spectrum_analyzer: Mutex<AdvancedSpectrumAnalyzerTab<S>>,
-    pub status_bar: Mutex<StatusBar<S>>,
+struct Tabs {
+    pub main: Mutex<MainTab>,
+    pub advanced_imu: Mutex<AdvancedImuTab>,
+    pub advanced_magnetometer: Mutex<AdvancedMagnetometerTab>,
+    pub advanced_networking: Mutex<AdvancedNetworkingTab>,
+    pub advanced_system_monitor: Mutex<AdvancedSystemMonitorTab>,
+    pub baseline: Mutex<BaselineTab>,
+    pub tracking_signals: Mutex<TrackingSignalsTab>,
+    pub tracking_sky_plot: Mutex<TrackingSkyPlotTab>,
+    pub solution: Mutex<SolutionTab>,
+    pub observation: Mutex<ObservationTab>,
+    pub solution_velocity: Mutex<SolutionVelocityTab>,
+    pub advanced_spectrum_analyzer: Mutex<AdvancedSpectrumAnalyzerTab>,
+    pub status_bar: Mutex<StatusBar>,
     pub update: Mutex<UpdateTab>,
 }
 
-impl<S: types::CapnProtoSender> Tabs<S> {
+impl Tabs {
     fn new(
         shared_state: shared_state::SharedState,
-        client_sender: S,
+        client_sender: client_sender::BoxedClientSender,
         msg_sender: types::MsgSender,
     ) -> Self {
         Self {

--- a/console_backend/src/observation_tab.rs
+++ b/console_backend/src/observation_tab.rs
@@ -3,11 +3,10 @@ use capnp::message::Builder;
 use log::warn;
 use std::collections::{BTreeMap, HashMap};
 
+use crate::client_sender::BoxedClientSender;
 use crate::shared_state::SharedState;
-use crate::types::{CapnProtoSender, ObservationMsg, SignalCodes};
-use crate::utils::{compute_doppler, sec_to_ns};
-
-use crate::utils::serialize_capnproto_builder;
+use crate::types::{ObservationMsg, SignalCodes};
+use crate::utils::{compute_doppler, sec_to_ns, serialize_capnproto_builder};
 
 #[derive(Clone, Debug)]
 pub struct ObservationTableRow {
@@ -119,15 +118,15 @@ impl Default for ObservationTable {
 }
 
 #[derive(Debug)]
-pub struct ObservationTab<S: CapnProtoSender> {
-    pub client_sender: S,
+pub struct ObservationTab {
+    pub client_sender: BoxedClientSender,
     pub shared_state: SharedState,
     pub remote: ObservationTable,
     pub local: ObservationTable,
 }
 
-impl<S: CapnProtoSender> ObservationTab<S> {
-    pub fn new(shared_state: SharedState, client_sender: S) -> ObservationTab<S> {
+impl ObservationTab {
+    pub fn new(shared_state: SharedState, client_sender: BoxedClientSender) -> ObservationTab {
         ObservationTab {
             client_sender,
             shared_state,

--- a/console_backend/src/types.rs
+++ b/console_backend/src/types.rs
@@ -19,7 +19,6 @@ use crate::piksi_tools_constants::{
 use crate::utils::{mm_to_m, ms_to_sec};
 use anyhow::Context;
 use chrono::{DateTime, Utc};
-use crossbeam::channel;
 use ordered_float::OrderedFloat;
 use sbp::link::Event;
 use sbp::messages::{
@@ -236,41 +235,6 @@ macro_rules! zip {
                 $crate::unzip!(a => (a) $( , $y )*)
             )
     };
-}
-
-pub trait CapnProtoSender: Debug + Clone + Send + Sync + 'static {
-    fn send_data(&mut self, msg_bytes: Vec<u8>);
-}
-
-#[derive(Debug, Clone)]
-pub struct ClientSender {
-    pub inner: channel::Sender<Vec<u8>>,
-    pub connected: ArcBool,
-}
-impl ClientSender {
-    pub fn new(inner: channel::Sender<Vec<u8>>) -> Self {
-        Self {
-            inner,
-            connected: ArcBool::new_with(true),
-        }
-    }
-}
-impl CapnProtoSender for ClientSender {
-    fn send_data(&mut self, msg_bytes: Vec<u8>) {
-        if self.connected.get() {
-            let _ = self.inner.send(msg_bytes);
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct TestSender {
-    pub inner: Vec<Vec<u8>>,
-}
-impl CapnProtoSender for TestSender {
-    fn send_data(&mut self, msg: Vec<u8>) {
-        self.inner.push(msg)
-    }
 }
 
 #[derive(Debug, Default)]

--- a/console_backend/tests/mem_benches.rs
+++ b/console_backend/tests/mem_benches.rs
@@ -7,9 +7,10 @@ mod mem_bench_impl {
     use sysinfo::{get_current_pid, ProcessExt, System, SystemExt};
 
     use console_backend::{
+        client_sender::ChannelSender,
         connection::ConnectionManager,
         shared_state::{ConnectionState, SharedState},
-        types::{ClientSender, RealtimeDelay},
+        types::RealtimeDelay,
     };
 
     const BENCH_FILEPATH: &str = "./tests/data/piksi-relay-1min.sbp";
@@ -82,7 +83,7 @@ mod mem_bench_impl {
         });
 
         let mut conn_watch = shared_state.watch_connection();
-        let client_send = ClientSender::new(client_send);
+        let client_send = ChannelSender::boxed(client_send);
         let conn_manager = ConnectionManager::new(client_send, shared_state);
 
         conn_manager.connect_to_file(


### PR DESCRIPTION
Something I've thought about before, boxing the sender means we don't need to pollute nearly everything with the generic type of the sender. I've found it a bit tedious to move things around because of that. Performance seems the same despite the dynamic dispatch

Also changes the trait name to `ClientSender` because the behavior it abstracts over is sending data to the frontend, not capnproto things 