### PR TITLE
bump sbp-settings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1523,9 +1523,9 @@ dependencies = [
 
 [[package]]
 name = "sbp-settings"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f13cb39dcec176cbc5f1676cb0faf3d14e753ae5a506304a5267345a751312a0"
+checksum = "ad2affc9a3b36ee5a8400cd478b86f99d8a95dafb0ff2d413bf3c17273becc79"
 dependencies = [
  "bindgen",
  "cmake",

--- a/console_backend/Cargo.toml
+++ b/console_backend/Cargo.toml
@@ -39,7 +39,7 @@ minreq = { version = "2.4.2", features = ["https"] }
 regex = { version = "1.5.4" }
 rust-ini = "0.17.0"
 sbp = { version = "4.0.3", features = ["json", "link", "swiftnav"] }
-sbp-settings = "0.3"
+sbp-settings = "0.4"
 env_logger = { version = "0.9", optional = true }
 mimalloc = { version = "0.1", default-features = false }
 


### PR DESCRIPTION
Logs from the c side of libsettings should now show up in the log panel rather than stderr