### PR TITLE
Fix Usage String [CPP-352]

### DIFF
--- a/console_backend/src/cli_options.rs
+++ b/console_backend/src/cli_options.rs
@@ -84,6 +84,7 @@ impl FromStr for CliSbpLogging {
 
 #[derive(Clap, Debug)]
 #[clap(name = "swift_navigation_console", about = "Swift Navigation Console.")]
+#[clap(override_usage = "swiftnav-console [FLAGS] [OPTIONS] [SUBCOMMANDS]")]
 pub struct CliOptions {
     #[clap(subcommand)]
     pub input: Option<Input>,


### PR DESCRIPTION
Override the usage string so that it doesn't show 'python3' as
the command.