### PR TITLE
Update drawio-sync.yaml

### DIFF
--- a/.github/workflows/drawio-sync.yaml
+++ b/.github/workflows/drawio-sync.yaml
@@ -21,7 +21,7 @@ jobs:
         with:
           format: png
           remove-page-suffix: true
-          transparent: true
+          transparent: false
 
       - name: Get author and committer info from HEAD commit
         uses: rlespinasse/git-commit-data-action@v1.x


### PR DESCRIPTION
Don't export transparent pngs so that they still look readable with the github dark theme