### PR TITLE
solution velocity tab: Make units drop down wider

### DIFF
--- a/resources/Constants/Constants.qml
+++ b/resources/Constants/Constants.qml
@@ -509,7 +509,7 @@ QtObject {
         readonly property int xAxisLabelsAngle: 45
         readonly property string xAxisTitleText: "GPS Time of Week"
         readonly property int xAxisMinOffsetFromMaxSeconds: 20
-        readonly property int unitDropdownWidth: 50
+        readonly property int unitDropdownWidth: 75
         readonly property int chartHeightOffset: 0
         readonly property int chartBottomMargin: 30
         readonly property int legendBottomMargin: 120


### PR DESCRIPTION
Increase the width of the units drop down box so that it doesn't clip.

Before:
![Screenshot from 2021-12-13 13-43-25](https://user-images.githubusercontent.com/3880246/145744257-a3b5005f-6cc6-476c-a310-73ffcc11b344.png)

After:
![Screenshot from 2021-12-13 13-40-55](https://user-images.githubusercontent.com/3880246/145744215-aea15760-6959-40d0-b719-595c57be9c37.png)

