### PR TITLE
add units to baseline table items [CPP-452]

### DIFF
--- a/console_backend/src/constants.rs
+++ b/console_backend/src/constants.rs
@@ -79,7 +79,7 @@ pub(crate) const DOWN: &str = "D [m]";
 pub(crate) const DIST: &str = "Dist [m]";
 pub(crate) const FLAGS: &str = "Flags";
 pub(crate) const MODE: &str = "Mode";
-pub(crate) const HEADING: &str = "Heading [^]";
+pub(crate) const HEADING: &str = "Heading [°]";
 
 pub const BASELINE_DATA_KEYS: &[&str] = &[N_FLOAT, N_FIXED, N_DGNSS, E_FLOAT, E_FIXED, E_DGNSS];
 


### PR DESCRIPTION
Added the ones mentioned in the [ticket](https://swift-nav.atlassian.net/jira/software/projects/CPP/boards/159?assignee=5e4c5b0cc8ec310c955b957a&selectedIssue=CPP-452), also I assume we wanted united for `E` and `D` in addition to `N`. Also for heading the ticket said `[^]`. I assume it's in degrees, should we be using `[°]` instead? is `^` a convention? Similarly, should `Vert Acc`/`Horiz Acc` be `[m/s]`?

![Screenshot from 2021-12-15 10-09-22](https://user-images.githubusercontent.com/8651036/146241646-98d3603a-b69e-4e2d-a7e8-2dcb6d5941fd.png)
