### PR TITLE
Build fileio in CI for Windows/Linux [DEVINFRA-611]

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -175,6 +175,10 @@ jobs:
 
     name: Build Binaries
 
+    needs:
+      - checks
+      - backend_bench
+
     strategy:
       matrix:
         os:
@@ -299,7 +303,7 @@ jobs:
       - name: Build ${{ runner.os }} fileio binary.
         run: |
           cargo build --bin fileio --features="env_logger" --release
-        # Building on Mac currently not working
+        # Building on Mac currently not working (DEVINFRA-612)
         if: matrix.os.name != 'windows-2019' && matrix.os.name != 'macos-10.15'
 
       - name: Build ${{ runner.os }} fileio binary.


### PR DESCRIPTION
Builds the fileIO binary for Windows and Linux in CI. This is currently not working for Mac, see https://swift-nav.atlassian.net/browse/DEVINFRA-612 .