### PR TITLE
Add timeout for debugging crash.

### DIFF
--- a/swiftnav_console/main.py
+++ b/swiftnav_console/main.py
@@ -4,6 +4,7 @@ import argparse
 import os
 import sys
 import threading
+import time
 
 from typing import List, Any, Optional, Tuple
 
@@ -221,7 +222,10 @@ capnp.remove_import_hook()  # pylint: disable=no-member
 
 
 def receive_messages(app_, backend, messages):
+    start = time.time()
     while True:
+        if time.time() - start > 10:
+            return app_.quit()
         buffer = backend.fetch_message()
         if not buffer:
             print("terminating GUI loop", file=sys.stderr)


### PR DESCRIPTION
I came up with a bit of a hack to recreate the intermittent crash we have been seeing. Initially I have been using this timeout assuming the issue was related to the settings but I actually think it is related to how we are juggling received data from our backend to qt slots/signals. That being said, using a file, in theory, should also result in the same behavior.

* Build the app:
`cargo make build-dist`

* Create a file `~/.gdbinit` and add this line:
`set pagination off`

* Then run (test w/ settings):
`for i in {1..1000}; do rust-gdb -ex='set confirm on' -ex run -ex=quit --args console --log-level DEBUG --log-stderr tcp 10.1.54.1;echo ${i};done`

* Or run (test w/o settings), segfault after 54 iterations:
`for i in {1..1000}; do rust-gdb -ex='set confirm on' -ex run -ex=quit --args console --log-level DEBUG --log-stderr file ../console_backend/tests/data/piksi-relay-1min.sbp;echo ${i};done`