### PR TITLE
Show unset settings in the settings table [CPP-555]

### DIFF
--- a/console_backend/src/settings_tab.rs
+++ b/console_backend/src/settings_tab.rs
@@ -479,6 +479,7 @@ pub struct SaveRequest {
 
 struct Settings {
     inner: IndexMap<String, IndexMap<String, SettingsEntry>>,
+    default: SettingValue,
 }
 
 impl Settings {
@@ -491,6 +492,7 @@ impl Settings {
                         .insert(setting.name.clone(), SettingsEntry::new(setting));
                     settings
                 }),
+            default: SettingValue::String("".into()),
         }
     }
 
@@ -498,11 +500,11 @@ impl Settings {
         self.inner.values().fold(Vec::new(), |mut groups, group| {
             let group: Vec<_> = group
                 .values()
-                .filter_map(|setting| {
-                    setting
-                        .value
-                        .as_ref()
-                        .map(|v| (setting.setting.as_ref(), v))
+                .map(|setting| {
+                    setting.value.as_ref().map_or_else(
+                        || (setting.setting.as_ref(), &self.default),
+                        |v| (setting.setting.as_ref(), v),
+                    )
                 })
                 .collect();
             if !group.is_empty() {


### PR DESCRIPTION
Sets the value for unset settings to the empty string (which the frontend displays as '---')

![ntrip1](https://user-images.githubusercontent.com/8651036/148278114-920edf5a-7113-479b-be80-15ceb909a436.png)

A quirk of this implementation causes all setting values to display as `---` briefly when you refresh the settings. Current behavior is that the whole table disappears during the refresh. I actually kind of like this new behavior better but the old console removes the whole table during a refresh so not sure if it's okay.

https://user-images.githubusercontent.com/8651036/148278268-17b5c55a-e435-4b32-9ffe-cb9b398fc372.mp4