### PR TITLE
Fix connection dialog constant.

### DIFF
--- a/resources/ConnectionScreen.qml
+++ b/resources/ConnectionScreen.qml
@@ -90,7 +90,7 @@ Item {
                     RadioButton {
                         id: tcpRadio
 
-                        checked: previous_connection_type == "TCP"
+                        checked: previous_connection_type == "Tcp"
                         text: tcp_ip
                         onToggled: dialogRect.forceActiveFocus()
                     }


### PR DESCRIPTION
Fix constant used in QML causing a bug in the connection dialog.