### PR TITLE
Bake in QT_QPA_PLATFORM env var for wayland use[CPP-256]

### DIFF
--- a/entrypoint/src/main.rs
+++ b/entrypoint/src/main.rs
@@ -18,7 +18,7 @@ fn attach_console() {
 fn handle_wayland() {
     #[cfg(target_os = "linux")]
     {
-        if std::env::var("XDG_SESSION_TYPE").unwrap_or_else(|_| "".to_string()) == "wayland" {
+        if std::env::var("XDG_SESSION_TYPE").as_deref() == Ok("wayland") {
             std::env::set_var("QT_QPA_PLATFORM", "wayland");
         }
     }


### PR DESCRIPTION
Needed to prevent crash when running on Debian 10.9 or higher as well as any other linux OS running wayland.