### PR TITLE
Silence error sending msg over udp[CPP-489]

### DIFF
--- a/console_backend/src/advanced_networking_tab.rs
+++ b/console_backend/src/advanced_networking_tab.rs
@@ -161,7 +161,9 @@ impl AdvancedNetworkingTab {
             if let Some(client) = &mut self.client {
                 if self.all_messages || OBS_MSGS.contains(&msg.message_type()) {
                     if let Ok(frame) = sbp::to_vec(msg) {
-                        if let Err(_e) = client.send(&frame) {}
+                        if let Err(_e) = client.send(&frame) {
+                            // Need to squelch error for the case of no client listening.
+                        }
                     }
                 }
             } else {


### PR DESCRIPTION
The std::net::UdpSocket we are using implements a nontraditional version of udp with a connection. "Although UDP is a connectionless protocol, this implementation provides an interface to set an address where data should be sent and received from." https://doc.rust-lang.org/std/net/struct.UdpSocket.html

* This change silences the result of sending a data packet.
  - If not it will throw an error if nothing listens to the udp port.
* Also sets SO_BROADCAST option.
* Also changes the bind address to "0.0.0.0:0" to allow the host to automatically select the port as opposed to hardcoding it.