### PR TITLE
Add suggestions to Mag/Spec/IMU tabs[CPP-490][CPP-559]

### DIFF
--- a/resources/AdvancedTabComponents/AdvancedImuTab.qml
+++ b/resources/AdvancedTabComponents/AdvancedImuTab.qml
@@ -19,7 +19,7 @@ Item {
         id: advancedImuArea
 
         anchors.fill: parent
-        visible: false
+        visible: true
 
         ChartView {
             id: advancedImuChart
@@ -27,7 +27,7 @@ Item {
             Layout.fillWidth: true
             Layout.fillHeight: true
             Layout.alignment: Qt.AlignTop
-            visible: false
+            visible: true
             title: Constants.advancedImu.title
             titleColor: Constants.commonChart.titleColor
             plotAreaColor: Constants.commonChart.areaColor
@@ -106,6 +106,7 @@ Item {
 
                 tickInterval: Constants.advancedImu.xAxisTickCount
                 tickType: ValueAxis.TicksDynamic
+                labelFormat: "%d"
                 min: Constants.advancedImu.xAxisMin
                 max: Constants.advancedImu.xAxisMax
             }
@@ -115,8 +116,27 @@ Item {
 
                 tickInterval: Constants.advancedImu.yAxisTickCount
                 tickType: ValueAxis.TicksDynamic
+                labelFormat: "%d"
                 min: Constants.advancedImu.yAxisMin
                 max: Constants.advancedImu.yAxisMax
+            }
+
+            LineSeries {
+                name: "emptySeries"
+                axisYRight: advancedImuYAxis
+                axisX: advancedImuXAxis
+                color: "transparent"
+
+                XYPoint {
+                    x: 0
+                    y: 0
+                }
+
+                XYPoint {
+                    x: 1
+                    y: 1
+                }
+
             }
 
             Timer {
@@ -159,18 +179,17 @@ Item {
         RowLayout {
             id: textDataRow
 
-            visible: false
+            visible: true
             Layout.fillWidth: true
             Layout.preferredHeight: Constants.advancedImu.urlBarHeight
             Layout.alignment: Qt.AlignBottom
 
             Label {
                 text: Constants.advancedImu.textDataLabels[0]
-                Layout.preferredWidth: Constants.advancedImu.textDataLabelWidth
             }
 
             Rectangle {
-                Layout.fillWidth: true
+                Layout.preferredWidth: parent.width / 15
                 Layout.preferredHeight: Constants.advancedImu.textDataBarHeight
                 Layout.alignment: Qt.AlignVCenter
                 border.width: Constants.advancedImu.textDataBarBorderWidth
@@ -182,17 +201,17 @@ Item {
                     anchors.fill: parent
                     anchors.margins: Constants.advancedImu.textDataBarMargin
                     font.pointSize: Constants.mediumPointSize
+                    text: "0.00 C"
                 }
 
             }
 
             Label {
                 text: Constants.advancedImu.textDataLabels[1]
-                Layout.preferredWidth: Constants.advancedImu.textDataLabelWidth
             }
 
             Rectangle {
-                Layout.fillWidth: true
+                Layout.preferredWidth: parent.width / 15
                 Layout.preferredHeight: Constants.advancedImu.textDataBarHeight
                 Layout.alignment: Qt.AlignVCenter
                 border.width: Constants.advancedImu.textDataBarBorderWidth
@@ -204,17 +223,17 @@ Item {
                     anchors.fill: parent
                     anchors.margins: Constants.advancedImu.textDataBarMargin
                     font.pointSize: Constants.mediumPointSize
+                    text: "0x00"
                 }
 
             }
 
             Label {
                 text: Constants.advancedImu.textDataLabels[2]
-                Layout.preferredWidth: Constants.advancedImu.textDataLabelWidth
             }
 
             Rectangle {
-                Layout.fillWidth: true
+                Layout.preferredWidth: parent.width / 15
                 Layout.preferredHeight: Constants.advancedImu.textDataBarHeight
                 Layout.alignment: Qt.AlignVCenter
                 border.width: Constants.advancedImu.textDataBarBorderWidth
@@ -226,17 +245,17 @@ Item {
                     anchors.fill: parent
                     anchors.margins: Constants.advancedImu.textDataBarMargin
                     font.pointSize: Constants.mediumPointSize
+                    text: "0.00 g"
                 }
 
             }
 
             Label {
                 text: Constants.advancedImu.textDataLabels[3]
-                Layout.preferredWidth: Constants.advancedImu.textDataLabelWidth
             }
 
             Rectangle {
-                Layout.fillWidth: true
+                Layout.preferredWidth: parent.width / 15
                 Layout.preferredHeight: Constants.advancedImu.textDataBarHeight
                 Layout.alignment: Qt.AlignVCenter
                 border.width: Constants.advancedImu.textDataBarBorderWidth
@@ -248,17 +267,17 @@ Item {
                     anchors.fill: parent
                     anchors.margins: Constants.advancedImu.textDataBarMargin
                     font.pointSize: Constants.mediumPointSize
+                    text: "0.00 g"
                 }
 
             }
 
             Label {
                 text: Constants.advancedImu.textDataLabels[4]
-                Layout.preferredWidth: Constants.advancedImu.textDataLabelWidth
             }
 
             Rectangle {
-                Layout.fillWidth: true
+                Layout.preferredWidth: parent.width / 15
                 Layout.preferredHeight: Constants.advancedImu.textDataBarHeight
                 Layout.alignment: Qt.AlignVCenter
                 border.width: Constants.advancedImu.textDataBarBorderWidth
@@ -270,6 +289,20 @@ Item {
                     anchors.fill: parent
                     anchors.margins: Constants.advancedImu.textDataBarMargin
                     font.pointSize: Constants.mediumPointSize
+                    text: "0.00 g"
+                }
+
+            }
+
+            Rectangle {
+                Layout.fillWidth: true
+                Layout.preferredHeight: Constants.advancedMagnetometer.suggestionTextRowHeight
+
+                Label {
+                    text: Constants.advancedMagnetometer.suggestionText
+                    font.italic: true
+                    antialiasing: true
+                    anchors.horizontalCenter: parent.horizontalCenter
                 }
 
             }

--- a/resources/AdvancedTabComponents/AdvancedMagnetometerTab.qml
+++ b/resources/AdvancedTabComponents/AdvancedMagnetometerTab.qml
@@ -19,7 +19,8 @@ Item {
         id: advancedMagnetometerArea
 
         anchors.fill: parent
-        visible: false
+        visible: true
+        spacing: 0
 
         ChartView {
             id: advancedMagnetometerChart
@@ -108,6 +109,7 @@ Item {
                 max: Constants.advancedMagnetometer.xAxisMax
                 tickInterval: Constants.advancedMagnetometer.xAxisTickCount
                 tickType: ValueAxis.TicksDynamic
+                labelFormat: "%d"
             }
 
             SwiftValueAxis {
@@ -115,6 +117,25 @@ Item {
 
                 tickInterval: Constants.advancedMagnetometer.yAxisTickCount
                 tickType: ValueAxis.TicksDynamic
+                labelFormat: "%d"
+            }
+
+            LineSeries {
+                name: "emptySeries"
+                axisYRight: advancedMagnetometerYAxis
+                axisX: advancedMagnetometerXAxis
+                color: "transparent"
+
+                XYPoint {
+                    x: 0
+                    y: -10
+                }
+
+                XYPoint {
+                    x: 1
+                    y: 10
+                }
+
             }
 
             Timer {
@@ -143,10 +164,23 @@ Item {
                         }
                     }
                     advancedMagnetometerArea.visible = true;
-                    advancedMagnetometerYAxis.min = advancedMagnetometerPoints.ymin;
-                    advancedMagnetometerYAxis.max = advancedMagnetometerPoints.ymax;
+                    advancedMagnetometerYAxis.min = advancedMagnetometerPoints.ymin - Constants.advancedMagnetometer.yAxisPadding;
+                    advancedMagnetometerYAxis.max = advancedMagnetometerPoints.ymax + Constants.advancedMagnetometer.yAxisPadding;
                     advancedMagnetometerPoints.fill_series(lines);
                 }
+            }
+
+        }
+
+        Rectangle {
+            Layout.fillWidth: true
+            Layout.preferredHeight: Constants.advancedMagnetometer.suggestionTextRowHeight
+
+            Label {
+                text: Constants.advancedMagnetometer.suggestionText
+                font.italic: true
+                antialiasing: true
+                anchors.horizontalCenter: parent.horizontalCenter
             }
 
         }

--- a/resources/AdvancedTabComponents/AdvancedSpectrumAnalyzerTab.qml
+++ b/resources/AdvancedTabComponents/AdvancedSpectrumAnalyzerTab.qml
@@ -19,7 +19,8 @@ Item {
         id: advancedSpectrumAnalyzerArea
 
         anchors.fill: parent
-        visible: false
+        visible: true
+        spacing: 0
 
         ChartView {
             id: advancedSpectrumAnalyzerChart
@@ -47,6 +48,7 @@ Item {
                 titleText: Constants.advancedSpectrumAnalyzer.xAxisTitleText
                 tickInterval: Constants.advancedSpectrumAnalyzer.xAxisTickCount
                 tickType: ValueAxis.TicksDynamic
+                labelFormat: "%d"
             }
 
             SwiftValueAxis {
@@ -55,6 +57,25 @@ Item {
                 titleText: Constants.advancedSpectrumAnalyzer.yAxisTitleText
                 tickInterval: Constants.advancedSpectrumAnalyzer.yAxisTickCount
                 tickType: ValueAxis.TicksDynamic
+                labelFormat: "%d"
+            }
+
+            LineSeries {
+                name: "emptySeries"
+                axisYRight: advancedSpectrumAnalyzerYAxis
+                axisX: advancedSpectrumAnalyzerXAxis
+                color: "transparent"
+
+                XYPoint {
+                    x: -1
+                    y: -1
+                }
+
+                XYPoint {
+                    x: 1
+                    y: 1
+                }
+
             }
 
             Timer {
@@ -95,8 +116,7 @@ Item {
             id: channelSelectionRow
 
             Layout.fillWidth: true
-            Layout.preferredHeight: Constants.advancedSpectrumAnalyzer.dropdownRowHeight
-            Layout.alignment: Qt.AlignBottom
+            Layout.maximumHeight: Constants.advancedSpectrumAnalyzer.dropdownRowHeight
         }
 
     }

--- a/resources/AdvancedTabComponents/AdvancedSpectrumAnalyzerTabChannelBar.qml
+++ b/resources/AdvancedTabComponents/AdvancedSpectrumAnalyzerTabChannelBar.qml
@@ -5,56 +5,47 @@ import QtQuick.Controls 2.12
 import QtQuick.Layouts 1.15
 import SwiftConsole 1.0
 
-Item {
+RowLayout {
+    id: channelSelectionRowLayout
+
     property alias dropdownIdx: channelDropdown.currentIndex
 
-    width: parent.width
-    height: parent.height
-    Component.onCompleted: {
+    Item {
+        Layout.preferredWidth: parent.width / 6
     }
 
-    RowLayout {
-        id: channelSelectionRowLayout
+    Label {
+        text: Constants.advancedSpectrumAnalyzer.dropdownLabel
+        font.bold: true
+        color: Constants.commonChart.titleColor
+        antialiasing: true
+    }
 
-        width: parent.width
-        height: parent.height
+    ComboBox {
+        id: channelDropdown
 
-        Item {
-            Layout.preferredWidth: parent.width / 6
+        Layout.preferredHeight: Constants.advancedSpectrumAnalyzer.dropdownHeight
+        Layout.preferredWidth: Constants.advancedSpectrumAnalyzer.dropdownWidth
+        topInset: 0
+        bottomInset: 0
+        model: Constants.advancedSpectrumAnalyzer.dropdownModel
+        onActivated: {
+            data_model.advanced_spectrum_analyzer_channel(currentIndex);
         }
+    }
 
-        Label {
-            text: Constants.advancedSpectrumAnalyzer.dropdownLabel
-            font.bold: true
-            color: Constants.commonChart.titleColor
-            antialiasing: true
-        }
+    Item {
+        Layout.fillWidth: true
+    }
 
-        ComboBox {
-            id: channelDropdown
+    Label {
+        text: Constants.advancedSpectrumAnalyzer.dropdownRowSuggestionText
+        font.italic: true
+        antialiasing: true
+    }
 
-            Layout.preferredHeight: Constants.advancedSpectrumAnalyzer.dropdownHeight
-            Layout.preferredWidth: Constants.advancedSpectrumAnalyzer.dropdownWidth
-            model: Constants.advancedSpectrumAnalyzer.dropdownModel
-            onActivated: {
-                data_model.advanced_spectrum_analyzer_channel(currentIndex);
-            }
-        }
-
-        Item {
-            Layout.fillWidth: true
-        }
-
-        Label {
-            text: Constants.advancedSpectrumAnalyzer.dropdownRowSuggestionText
-            font.italic: true
-            antialiasing: true
-        }
-
-        Item {
-            Layout.preferredWidth: parent.width / 6
-        }
-
+    Item {
+        Layout.preferredWidth: parent.width / 6
     }
 
 }

--- a/resources/Constants/Constants.qml
+++ b/resources/Constants/Constants.qml
@@ -360,6 +360,9 @@ QtObject {
         readonly property int yAxisTickCount: 20
         readonly property int legendBottomMargin: 60
         readonly property int legendLeftMargin: 50
+        readonly property string suggestionText: "Enable in Settings tab under the \"imu\" group."
+        readonly property int suggestionTextRowHeight: 20
+        readonly property int yAxisPadding: 10
     }
 
     advancedSpectrumAnalyzer: QtObject {
@@ -369,12 +372,12 @@ QtObject {
         readonly property real yAxisTickCount: 2.5
         readonly property string yAxisTitleText: "Amplitude (dB)"
         readonly property string xAxisTitleText: "Frequency (MHz)"
-        readonly property int dropdownRowHeight: 35
-        readonly property int dropdownHeight: 35
+        readonly property int dropdownRowHeight: 20
+        readonly property int dropdownHeight: 20
         readonly property int dropdownWidth: 100
         readonly property var dropdownModel: ["Channel 1", "Channel 2", "Channel 3", "Channel 4"]
         readonly property string dropdownLabel: "Channel Selection:"
-        readonly property string dropdownRowSuggestionText: "Enable in Settings Tab under the \"System Monitor\" group."
+        readonly property string dropdownRowSuggestionText: "Enable in Settings tab under the \"system_monitor\" group."
         readonly property int rowTextHeight: 30
         readonly property int rowTextMargins: 5
     }


### PR DESCRIPTION
* Makes IMU tab visible again.
* Adds a suggestion for the setting group to check for enabling Magnetometer and IMU tabs (spectrum analyzer already had one). Also reduced some of the complexity of the qml.
* Added an empty and transparent series to Magnetometer / Spectrum Analyzer / IMU tabs so they are always visible.