### PR TITLE
Always create initial logging directory.[CPP-407]

### DIFF
--- a/console_backend/src/main_tab.rs
+++ b/console_backend/src/main_tab.rs
@@ -14,7 +14,7 @@ use crate::constants::{
 };
 use crate::output::{CsvLogging, SbpLogger};
 use crate::shared_state::{create_directory, SharedState};
-use crate::utils::{pathbuf_to_unix_filepath, refresh_loggingbar, refresh_loggingbar_recording};
+use crate::utils::{refresh_loggingbar, refresh_loggingbar_recording};
 use crate::{client_sender::BoxedClientSender, shared_state::ConnectionState};
 use crate::{common_constants::SbpLogging, shared_state::SbpLoggingStatsState};
 
@@ -160,8 +160,8 @@ impl MainTab {
                     }
                     Err(e) => {
                         error!(
-                            "issue creating file, {:?}, error, {}",
-                            pathbuf_to_unix_filepath(sbp_log_file),
+                            "issue creating file, {}, error, {}",
+                            sbp_log_file.display(),
                             e
                         );
                         None
@@ -178,8 +178,8 @@ impl MainTab {
                     }
                     Err(e) => {
                         error!(
-                            "issue creating file, {:?}, error, {}",
-                            pathbuf_to_unix_filepath(sbp_json_log_file),
+                            "issue creating file, {}, error, {}",
+                            sbp_json_log_file.display(),
                             e
                         );
                         None

--- a/console_backend/src/shared_state.rs
+++ b/console_backend/src/shared_state.rs
@@ -34,7 +34,7 @@ use crate::settings_tab;
 use crate::solution_tab::LatLonUnits;
 use crate::types::ArcBool;
 use crate::update_tab::UpdateTabUpdate;
-use crate::utils::{pathbuf_to_unix_filepath, send_conn_state};
+use crate::utils::send_conn_state;
 use crate::watch::{WatchReceiver, Watched};
 use crate::{client_sender::BoxedClientSender, main_tab::logging_stats_thread};
 use crate::{common_constants::ConnectionType, connection::Connection};
@@ -169,7 +169,7 @@ impl SharedState {
         self.lock().solution_tab.velocity_tab.log_file = match CsvSerializer::new(path) {
             Ok(vel_csv) => Some(vel_csv),
             Err(e) => {
-                error!("issue creating file, {:?}, error, {}", path, e);
+                error!("issue creating file, {}, error, {}", path.display(), e);
                 None
             }
         }
@@ -185,7 +185,7 @@ impl SharedState {
         self.lock().solution_tab.position_tab.log_file = match CsvSerializer::new(path) {
             Ok(vel_csv) => Some(vel_csv),
             Err(e) => {
-                error!("issue creating file, {:?}, error, {}", path, e);
+                error!("issue creating file, {}, error, {}", path.display(), e);
                 None
             }
         }
@@ -201,7 +201,7 @@ impl SharedState {
         self.lock().baseline_tab.log_file = match CsvSerializer::new(path) {
             Ok(vel_csv) => Some(vel_csv),
             Err(e) => {
-                error!("issue creating file, {:?}, error, {}", path, e);
+                error!("issue creating file, {}, error, {}", path.display(), e);
                 None
             }
         }
@@ -435,8 +435,8 @@ impl LoggingBarState {
         };
         if let Err(err) = fs::create_dir_all(&logging_directory) {
             error!(
-                "Unable to create directory, {:?}, {}.",
-                pathbuf_to_unix_filepath(logging_directory.clone()),
+                "Unable to create directory, {}, {}.",
+                logging_directory.display(),
                 err
             );
         }

--- a/console_backend/src/update_downloader.rs
+++ b/console_backend/src/update_downloader.rs
@@ -1,4 +1,4 @@
-use crate::{update_tab::UpdateTabContext, utils::pathbuf_to_unix_filepath};
+use crate::update_tab::UpdateTabContext;
 use anyhow::bail;
 use curl::easy::Easy as Curl;
 use serde::{Deserialize, Serialize};
@@ -138,10 +138,7 @@ impl UpdateDownloader {
         if let Some(filename_) = filename {
             let filepath = Path::new(&directory).join(filename_);
             if !directory.exists() {
-                let msg = format!(
-                    "Creating directory: {:?}",
-                    pathbuf_to_unix_filepath(directory.clone())
-                );
+                let msg = format!("Creating directory: {}", directory.display());
                 if let Some(update_shared) = update_shared.clone() {
                     update_shared.fw_log_append(msg);
                 }
@@ -166,10 +163,7 @@ impl UpdateDownloader {
                 })
                 .expect("unable to configure download callback function");
             download.perform()?;
-            let msg = format!(
-                "Downloaded firmware file to: {:?}",
-                pathbuf_to_unix_filepath(filepath.clone())
-            );
+            let msg = format!("Downloaded firmware file to: {}", filepath.display());
             if let Some(update_shared) = update_shared {
                 update_shared.fw_log_append(msg);
             }

--- a/console_backend/src/update_tab.rs
+++ b/console_backend/src/update_tab.rs
@@ -1,4 +1,4 @@
-use anyhow::anyhow;
+use anyhow::{anyhow, bail};
 use capnp::message::Builder;
 use crossbeam::{
     channel::{self, Receiver, Sender},
@@ -546,7 +546,7 @@ fn firmware_upgrade(
                 _ => update_tab_context.fw_log_append(String::from("Image transfer failed.")),
             }
         } else {
-            return Err(anyhow!("Failed to read firmware file, {:?}.", filepath));
+            bail!("Failed to read firmware file, {}.", filepath.display());
         }
     }
     Ok(())

--- a/console_backend/src/utils.rs
+++ b/console_backend/src/utils.rs
@@ -1,6 +1,5 @@
 use std::collections::HashMap;
 use std::ops::Index;
-use std::path::PathBuf;
 
 use capnp::message::Builder;
 use capnp::message::HeapAllocator;
@@ -527,11 +526,6 @@ pub fn format_bool(b: bool) -> String {
     if b { "True" } else { "False" }.into()
 }
 
-/// Formats a pathbuf replacing double backslahes with single forward slashes.
-pub fn pathbuf_to_unix_filepath(path: PathBuf) -> PathBuf {
-    PathBuf::from(path.to_string_lossy().replace("\\", "/"))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -559,18 +553,6 @@ mod tests {
         assert_eq!(
             bytes_to_human_readable(u128::pow(1024, 9)),
             format!("{:.1}YB", 1024)
-        );
-    }
-
-    #[test]
-    fn pathbuf_to_unix_filepath_test() {
-        assert_eq!(
-            pathbuf_to_unix_filepath(PathBuf::from("C:\\Users\\user\\Desktop\\file.txt")),
-            PathBuf::from("C:/Users/user/Desktop/file.txt")
-        );
-        assert_eq!(
-            pathbuf_to_unix_filepath(PathBuf::from("C:\\Users\\user\\Desktop\\file.txt\\")),
-            PathBuf::from("C:/Users/user/Desktop/file.txt/")
         );
     }
 


### PR DESCRIPTION
* Attempts to create the current logging directory when the app starts up. 
  - Previously directories would only be created if a change in the target logging directory was initiated. 
* Also replaces double backslashes with forward slashes when printing pathbufs in a few places.