### PR TITLE
Update tab use base types and minor UI cleanup[CPP-499][CPP-506]

### DIFF
--- a/resources/BaseComponents/SwiftTextInput.qml
+++ b/resources/BaseComponents/SwiftTextInput.qml
@@ -1,0 +1,57 @@
+import "../Constants"
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Rectangle {
+    property alias text: textInput.text
+    property string placeholderText: ""
+    property color placeholderColor: Constants.updateTab.placeholderTextColor
+    property int rightMargin: 5
+    property int leftMargin: 5
+    property int topMargin: 2
+    property int bottomMargin: 0
+    property int borderWidth: Constants.genericTable.borderWidth
+    property bool readOnly: false
+    property var labelHorizontalAlignment: Text.AlignRight
+    property var fontFamily: Constants.genericTable.fontFamily
+    property font labelFont: Qt.font({
+        "family": Constants.genericTable.fontFamily,
+        "pointSize": Constants.largePointSize
+    })
+
+    signal textEdited()
+    signal editingFinished()
+
+    clip: true
+    border.width: borderWidth
+    Component.onCompleted: {
+        textInput.textEdited.connect(textEdited);
+        textInput.editingFinished.connect(editingFinished);
+    }
+
+    TextInput {
+        id: textInput
+
+        text: ""
+        cursorVisible: true
+        selectByMouse: true
+        readOnly: parent.readOnly
+        font: labelFont
+        anchors.fill: parent
+        anchors.leftMargin: leftMargin
+        anchors.rightMargin: rightMargin
+        anchors.topMargin: topMargin
+        anchors.bottomMargin: bottomMargin
+        anchors.verticalCenter: parent.verticalCenter
+
+        Label {
+            id: placeholder
+
+            text: placeholderText
+            color: placeholderColor
+            visible: !textInput.text
+        }
+
+    }
+
+}

--- a/resources/BaseComponents/SwiftTextbox.qml
+++ b/resources/BaseComponents/SwiftTextbox.qml
@@ -1,0 +1,29 @@
+import "../Constants"
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+
+Rectangle {
+    property string text: ""
+    property int rightMargin: 0
+    property int leftMargin: 0
+    property int topMargin: 0
+    property int bottomMargin: 0
+    property var labelHorizontalAlignment: Text.AlignRight
+    property var fontFamily: Constants.genericTable.fontFamily
+    property font labelFont: Qt.font({
+        "family": Constants.genericTable.fontFamily,
+        "pointSize": Constants.largePointSize
+    })
+
+    Label {
+        text: parent.text
+        anchors.fill: parent
+        anchors.rightMargin: rightMargin
+        anchors.leftMargin: leftMargin
+        anchors.topMargin: topMargin
+        anchors.bottomMargin: bottomMargin
+        horizontalAlignment: labelHorizontalAlignment
+        font: labelFont
+    }
+
+}

--- a/resources/UpdateTab.qml
+++ b/resources/UpdateTab.qml
@@ -57,8 +57,6 @@ MainTab {
 
     ColumnLayout {
         anchors.fill: parent
-        width: parent.width
-        height: parent.height
         anchors.margins: Constants.updateTab.outerMargins
 
         Rectangle {
@@ -121,6 +119,8 @@ MainTab {
 
             Label {
                 text: Constants.updateTab.firmwareUpgradeStatusTitle
+                font.family: Constants.genericTable.fontFamily
+                font.pointSize: Constants.largePointSize
             }
 
         }
@@ -132,7 +132,7 @@ MainTab {
             Layout.rightMargin: Constants.updateTab.innerMargins
             Layout.bottomMargin: Constants.updateTab.innerMargins
 
-            TextArea {
+            TextEdit {
                 id: fwLogTextArea
 
                 readOnly: true
@@ -140,6 +140,8 @@ MainTab {
                 selectByKeyboard: true
                 cursorVisible: true
                 activeFocusOnPress: false
+                font.family: Constants.genericTable.fontFamily
+                font.pointSize: Constants.largePointSize
             }
 
         }
@@ -151,6 +153,8 @@ MainTab {
 
             Label {
                 text: Constants.updateTab.fileioAndProductFeatureToolTitle
+                font.family: Constants.genericTable.fontFamily
+                font.pointSize: Constants.largePointSize
             }
 
         }

--- a/resources/UpdateTabComponents/FileIOSelectLocalFileAndDestPath.qml
+++ b/resources/UpdateTabComponents/FileIOSelectLocalFileAndDestPath.qml
@@ -1,3 +1,4 @@
+import "../BaseComponents"
 import "../Constants"
 import QtQuick 2.15
 import QtQuick.Controls 2.15
@@ -14,53 +15,33 @@ Item {
     RowLayout {
         anchors.fill: parent
 
-        Rectangle {
+        SwiftTextbox {
             Layout.preferredWidth: Constants.updateTab.hardwareVersionElementsLabelWidth
             Layout.fillHeight: true
-
-            Label {
-                text: Constants.updateTab.fileioLocalFileLabel
-                anchors.fill: parent
-                anchors.rightMargin: Constants.updateTab.firmwareVersionElementsLabelRightMargin
-                horizontalAlignment: Text.AlignRight
-            }
-
+            text: Constants.updateTab.fileioLocalFileLabel
         }
 
-        Rectangle {
+        SwiftTextInput {
+            id: localFileTextInput
+
             Layout.fillWidth: true
             Layout.fillHeight: true
-            border.width: Constants.advancedImu.textDataBarBorderWidth
-            clip: true
-
-            TextInput {
-                id: localFileTextInput
-
-                text: ""
-                cursorVisible: true
-                selectByMouse: true
-                font.pointSize: Constants.largePointSize
-                font.family: Constants.genericTable.fontFamily
-                anchors.fill: parent
-                anchors.leftMargin: Constants.updateTab.firmwareVersionElementsLabelRightMargin
-                onTextEdited: {
-                    localTextEditing = true;
-                }
-                onEditingFinished: {
-                    let downloadLatestFirmware = false;
-                    let updateFirmware = false;
-                    let sendFileToDevice = false;
-                    let serialPromptConfirm = false;
-                    let updateLocalFilepath = null;
-                    let downloadDirectory = null;
-                    let fileioLocalFilepath = text;
-                    let fileioDestinationFilepath = null;
-                    let updateLocalFilename = null;
-                    data_model.update_tab([downloadLatestFirmware, updateFirmware, sendFileToDevice, serialPromptConfirm], updateLocalFilepath, downloadDirectory, fileioLocalFilepath, fileioDestinationFilepath, updateLocalFilename);
-                    localTextEditing = false;
-                }
+            onTextEdited: {
+                localTextEditing = true;
             }
-
+            onEditingFinished: {
+                let downloadLatestFirmware = false;
+                let updateFirmware = false;
+                let sendFileToDevice = false;
+                let serialPromptConfirm = false;
+                let updateLocalFilepath = null;
+                let downloadDirectory = null;
+                let fileioLocalFilepath = text;
+                let fileioDestinationFilepath = null;
+                let updateLocalFilename = null;
+                data_model.update_tab([downloadLatestFirmware, updateFirmware, sendFileToDevice, serialPromptConfirm], updateLocalFilepath, downloadDirectory, fileioLocalFilepath, fileioDestinationFilepath, updateLocalFilename);
+                localTextEditing = false;
+            }
         }
 
         Item {
@@ -82,6 +63,8 @@ Item {
             Label {
                 text: Constants.updateTab.dotDotDotLabel
                 anchors.centerIn: parent
+                font.family: Constants.genericTable.fontFamily
+                font.pointSize: Constants.largePointSize
             }
 
         }
@@ -113,53 +96,33 @@ Item {
             }
         }
 
-        Rectangle {
+        SwiftTextbox {
             Layout.preferredWidth: Constants.updateTab.hardwareVersionElementsLabelWidth * 2
             Layout.fillHeight: true
-
-            Label {
-                text: Constants.updateTab.fileioDestinationPathLabel
-                anchors.fill: parent
-                anchors.rightMargin: Constants.updateTab.firmwareVersionElementsLabelRightMargin
-                horizontalAlignment: Text.AlignRight
-            }
-
+            text: Constants.updateTab.fileioDestinationPathLabel
         }
 
-        Rectangle {
+        SwiftTextInput {
+            id: destinationPathTextInput
+
             Layout.fillWidth: true
             Layout.fillHeight: true
-            border.width: Constants.advancedImu.textDataBarBorderWidth
-            clip: true
-
-            TextInput {
-                id: destinationPathTextInput
-
-                text: ""
-                cursorVisible: true
-                selectByMouse: true
-                font.pointSize: Constants.largePointSize
-                font.family: Constants.genericTable.fontFamily
-                anchors.fill: parent
-                anchors.leftMargin: Constants.updateTab.firmwareVersionElementsLabelRightMargin
-                onTextEdited: {
-                    destinationTextEditing = true;
-                }
-                onEditingFinished: {
-                    let downloadLatestFirmware = false;
-                    let updateFirmware = false;
-                    let sendFileToDevice = false;
-                    let serialPromptConfirm = false;
-                    let updateLocalFilepath = null;
-                    let downloadDirectory = null;
-                    let fileioLocalFilepath = null;
-                    let fileioDestinationFilepath = text;
-                    let updateLocalFilename = null;
-                    data_model.update_tab([downloadLatestFirmware, updateFirmware, sendFileToDevice, serialPromptConfirm], updateLocalFilepath, downloadDirectory, fileioLocalFilepath, fileioDestinationFilepath, updateLocalFilename);
-                    destinationTextEditing = false;
-                }
+            onTextEdited: {
+                destinationTextEditing = true;
             }
-
+            onEditingFinished: {
+                let downloadLatestFirmware = false;
+                let updateFirmware = false;
+                let sendFileToDevice = false;
+                let serialPromptConfirm = false;
+                let updateLocalFilepath = null;
+                let downloadDirectory = null;
+                let fileioLocalFilepath = null;
+                let fileioDestinationFilepath = text;
+                let updateLocalFilename = null;
+                data_model.update_tab([downloadLatestFirmware, updateFirmware, sendFileToDevice, serialPromptConfirm], updateLocalFilepath, downloadDirectory, fileioLocalFilepath, fileioDestinationFilepath, updateLocalFilename);
+                destinationTextEditing = false;
+            }
         }
 
         Item {
@@ -190,6 +153,8 @@ Item {
             Label {
                 text: Constants.updateTab.fileioSendFileToDeviceButtonLabel
                 anchors.centerIn: parent
+                font.family: Constants.genericTable.fontFamily
+                font.pointSize: Constants.largePointSize
             }
 
         }

--- a/resources/UpdateTabComponents/FirmwareDownload.qml
+++ b/resources/UpdateTabComponents/FirmwareDownload.qml
@@ -17,6 +17,9 @@ Item {
 
         ColumnLayout {
             anchors.fill: parent
+            anchors.topMargin: Constants.updateTab.innerMargins
+            anchors.leftMargin: Constants.updateTab.innerMargins
+            anchors.rightMargin: Constants.updateTab.innerMargins
             width: parent.width
             height: parent.height
 
@@ -56,6 +59,8 @@ Item {
                 Label {
                     text: Constants.updateTab.downloadLatestFirmwareButtonLabel
                     anchors.centerIn: parent
+                    font.family: Constants.genericTable.fontFamily
+                    font.pointSize: Constants.largePointSize
                 }
 
             }

--- a/resources/UpdateTabComponents/FirmwareRevision.qml
+++ b/resources/UpdateTabComponents/FirmwareRevision.qml
@@ -1,46 +1,30 @@
+import "../BaseComponents"
 import "../Constants"
 import QtQuick 2.5
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
 
 Item {
-    property alias revision: hardwareRevisionText.text
+    property alias revision: hardwareRevisionText.placeholderText
 
     RowLayout {
         id: hardwareRevision
 
         anchors.fill: parent
-        width: parent.width
-        height: parent.height
-        spacing: Constants.updateTab.labelTextAreaSpacing
 
-        Rectangle {
+        SwiftTextbox {
             Layout.preferredWidth: Constants.updateTab.hardwareRevisionLabelWidth
             Layout.fillHeight: true
-            Layout.alignment: Qt.AlignBottom
-
-            Label {
-                text: Constants.updateTab.hardwareRevisionLabel
-            }
-
+            labelHorizontalAlignment: Text.AlignLeft
+            text: Constants.updateTab.hardwareRevisionLabel
         }
 
-        Rectangle {
+        SwiftTextInput {
+            id: hardwareRevisionText
+
             Layout.fillWidth: true
             Layout.fillHeight: true
-            Layout.alignment: Qt.AlignTop
-            border.width: Constants.advancedImu.textDataBarBorderWidth
-
-            Label {
-                id: hardwareRevisionText
-
-                text: ""
-                clip: true
-                anchors.fill: parent
-                color: Constants.updateTab.placeholderTextColor
-                anchors.margins: Constants.advancedImu.textDataBarMargin
-            }
-
+            readOnly: true
         }
 
     }

--- a/resources/UpdateTabComponents/FirmwareVersion.qml
+++ b/resources/UpdateTabComponents/FirmwareVersion.qml
@@ -1,3 +1,4 @@
+import "../BaseComponents"
 import "../Constants"
 import QtQuick 2.5
 import QtQuick.Controls 2.15
@@ -6,8 +7,8 @@ import QtQuick.Layouts 1.15
 import SwiftConsole 1.0
 
 Item {
-    property alias currentVersion: currentVersionText.text
-    property alias latestVersion: latestVersionText.text
+    property string currentVersion: ""
+    property string latestVersion: ""
     property alias localFileText: selectLocalFile.localFileText
     property alias localFileTextEditing: selectLocalFile.localFileTextEditing
     property alias upgradeButtonEnable: updateFirmwareButton.enabled
@@ -21,6 +22,9 @@ Item {
 
         ColumnLayout {
             anchors.fill: parent
+            anchors.topMargin: Constants.updateTab.innerMargins
+            anchors.leftMargin: Constants.updateTab.innerMargins
+            anchors.rightMargin: Constants.updateTab.innerMargins
             width: parent.width
             height: parent.height
             spacing: Constants.updateTab.firmwareVersionColumnSpacing
@@ -31,33 +35,19 @@ Item {
                 Layout.leftMargin: Constants.updateTab.innerMargins
                 Layout.rightMargin: Constants.updateTab.innerMargins
 
-                Rectangle {
+                SwiftTextbox {
                     width: Constants.updateTab.hardwareVersionElementsLabelWidth
                     height: parent.height
-
-                    Label {
-                        text: Constants.updateTab.firmwareVersionCurrentLabel
-                        anchors.fill: parent
-                        anchors.rightMargin: Constants.updateTab.firmwareVersionElementsLabelRightMargin
-                        horizontalAlignment: Text.AlignRight
-                    }
-
+                    rightMargin: Constants.updateTab.firmwareVersionElementsLabelRightMargin
+                    text: Constants.updateTab.firmwareVersionCurrentLabel
                 }
 
-                Rectangle {
+                SwiftTextInput {
                     width: parent.width - Constants.updateTab.hardwareVersionElementsLabelWidth
                     height: parent.height
-                    border.width: Constants.advancedImu.textDataBarBorderWidth
-
-                    Label {
-                        id: currentVersionText
-
-                        text: ""
-                        clip: true
-                        color: Constants.updateTab.placeholderTextColor
-                        anchors.centerIn: parent
-                    }
-
+                    placeholderText: currentVersion ? currentVersion : "Waiting for Piksi to send settings..."
+                    labelHorizontalAlignment: Text.AlignLeft
+                    readOnly: true
                 }
 
             }
@@ -68,33 +58,19 @@ Item {
                 Layout.leftMargin: Constants.updateTab.innerMargins
                 Layout.rightMargin: Constants.updateTab.innerMargins
 
-                Rectangle {
+                SwiftTextbox {
                     width: Constants.updateTab.hardwareVersionElementsLabelWidth
                     height: parent.height
-
-                    Label {
-                        text: Constants.updateTab.firmwareVersionLatestLabel
-                        anchors.fill: parent
-                        anchors.rightMargin: Constants.updateTab.firmwareVersionElementsLabelRightMargin
-                        horizontalAlignment: Text.AlignRight
-                    }
-
+                    rightMargin: Constants.updateTab.firmwareVersionElementsLabelRightMargin
+                    text: Constants.updateTab.firmwareVersionLatestLabel
                 }
 
-                Rectangle {
+                SwiftTextInput {
                     width: parent.width - Constants.updateTab.hardwareVersionElementsLabelWidth
                     height: parent.height
-                    border.width: Constants.advancedImu.textDataBarBorderWidth
-
-                    Label {
-                        id: latestVersionText
-
-                        text: ""
-                        clip: true
-                        color: Constants.updateTab.placeholderTextColor
-                        anchors.centerIn: parent
-                    }
-
+                    placeholderText: latestVersion ? latestVersion : "Loading latest firmware info..."
+                    labelHorizontalAlignment: Text.AlignLeft
+                    readOnly: true
                 }
 
             }
@@ -147,6 +123,8 @@ Item {
                     Label {
                         text: Constants.updateTab.updateFirmwareButtonLabel
                         anchors.centerIn: parent
+                        font.family: Constants.genericTable.fontFamily
+                        font.pointSize: Constants.largePointSize
                     }
 
                 }

--- a/resources/UpdateTabComponents/FirmwareVersionAndDownloadLabels.qml
+++ b/resources/UpdateTabComponents/FirmwareVersionAndDownloadLabels.qml
@@ -1,3 +1,4 @@
+import "../BaseComponents"
 import "../Constants"
 import QtQuick 2.5
 import QtQuick.Controls 2.15
@@ -9,24 +10,18 @@ Item {
         width: parent.width
         height: parent.height
 
-        Rectangle {
+        SwiftTextbox {
             Layout.preferredWidth: parent.width / 2
             Layout.fillHeight: true
-
-            Label {
-                text: Constants.updateTab.firmwareVersionTitle
-            }
-
+            labelHorizontalAlignment: Text.AlignLeft
+            text: Constants.updateTab.firmwareVersionTitle
         }
 
-        Rectangle {
+        SwiftTextbox {
             Layout.preferredWidth: parent.width / 2
             Layout.fillHeight: true
-
-            Label {
-                text: Constants.updateTab.firmwareDownloadTitle
-            }
-
+            labelHorizontalAlignment: Text.AlignLeft
+            text: Constants.updateTab.firmwareDownloadTitle
         }
 
     }

--- a/resources/UpdateTabComponents/SelectFirmwareDownloadDirectory.qml
+++ b/resources/UpdateTabComponents/SelectFirmwareDownloadDirectory.qml
@@ -1,3 +1,4 @@
+import "../BaseComponents"
 import "../Constants"
 import QtQuick 2.15
 import QtQuick.Controls 2.15
@@ -13,53 +14,34 @@ Item {
         anchors.fill: parent
         spacing: Constants.updateTab.firmwareVersionColumnSpacing
 
-        Rectangle {
+        SwiftTextbox {
             Layout.preferredWidth: Constants.updateTab.hardwareVersionElementsLabelWidth
             Layout.fillHeight: true
-
-            Label {
-                text: Constants.updateTab.firmwareDownloadDirectoryLabel
-                anchors.fill: parent
-                anchors.rightMargin: Constants.updateTab.firmwareVersionElementsLabelRightMargin
-                horizontalAlignment: Text.AlignRight
-            }
-
+            rightMargin: Constants.updateTab.firmwareVersionElementsLabelRightMargin
+            text: Constants.updateTab.firmwareDownloadDirectoryLabel
         }
 
-        Rectangle {
+        SwiftTextInput {
+            id: directoryInput
+
             Layout.fillWidth: true
             Layout.fillHeight: true
-            border.width: Constants.advancedImu.textDataBarBorderWidth
-            clip: true
-
-            TextInput {
-                id: directoryInput
-
-                text: ""
-                cursorVisible: true
-                selectByMouse: true
-                font.pointSize: Constants.largePointSize
-                font.family: Constants.genericTable.fontFamily
-                anchors.fill: parent
-                anchors.leftMargin: Constants.updateTab.firmwareVersionElementsLabelRightMargin
-                onTextEdited: {
-                    fwDirectoryEditing = true;
-                }
-                onEditingFinished: {
-                    let downloadLatestFirmware = false;
-                    let updateFirmware = false;
-                    let sendFileToDevice = false;
-                    let serialPromptConfirm = false;
-                    let updateLocalFilepath = null;
-                    let downloadDirectory = text;
-                    let fileioLocalFilepath = null;
-                    let fileioDestinationFilepath = null;
-                    let updateLocalFilename = null;
-                    data_model.update_tab([downloadLatestFirmware, updateFirmware, sendFileToDevice, serialPromptConfirm], updateLocalFilepath, downloadDirectory, fileioLocalFilepath, fileioDestinationFilepath, updateLocalFilename);
-                    fwDirectoryEditing = false;
-                }
+            onTextEdited: {
+                fwDirectoryEditing = true;
             }
-
+            onEditingFinished: {
+                let downloadLatestFirmware = false;
+                let updateFirmware = false;
+                let sendFileToDevice = false;
+                let serialPromptConfirm = false;
+                let updateLocalFilepath = null;
+                let downloadDirectory = text;
+                let fileioLocalFilepath = null;
+                let fileioDestinationFilepath = null;
+                let updateLocalFilename = null;
+                data_model.update_tab([downloadLatestFirmware, updateFirmware, sendFileToDevice, serialPromptConfirm], updateLocalFilepath, downloadDirectory, fileioLocalFilepath, fileioDestinationFilepath, updateLocalFilename);
+                fwDirectoryEditing = false;
+            }
         }
 
         Item {
@@ -81,6 +63,8 @@ Item {
             Label {
                 text: Constants.updateTab.dotDotDotLabel
                 anchors.centerIn: parent
+                font.family: Constants.genericTable.fontFamily
+                font.pointSize: Constants.largePointSize
             }
 
         }

--- a/resources/UpdateTabComponents/SelectLocalFile.qml
+++ b/resources/UpdateTabComponents/SelectLocalFile.qml
@@ -1,3 +1,4 @@
+import "../BaseComponents"
 import "../Constants"
 import QtQuick 2.15
 import QtQuick.Controls 2.15
@@ -12,63 +13,34 @@ Item {
         anchors.fill: parent
         spacing: Constants.updateTab.firmwareVersionColumnSpacing
 
-        Rectangle {
+        SwiftTextbox {
             Layout.preferredWidth: Constants.updateTab.hardwareVersionElementsLabelWidth
             Layout.fillHeight: true
-
-            Label {
-                text: Constants.updateTab.firmwareVersionLocalFileLabel
-                anchors.fill: parent
-                anchors.rightMargin: Constants.updateTab.firmwareVersionElementsLabelRightMargin
-                horizontalAlignment: Text.AlignRight
-            }
-
+            rightMargin: Constants.updateTab.firmwareVersionElementsLabelRightMargin
+            text: Constants.updateTab.firmwareVersionLocalFileLabel
         }
 
-        Rectangle {
+        SwiftTextInput {
+            id: localFileTextInput
+
             Layout.fillWidth: true
             Layout.fillHeight: true
-            border.width: Constants.advancedImu.textDataBarBorderWidth
-            clip: true
-
-            TextInput {
-                id: localFileTextInput
-
-                text: ""
-                cursorVisible: true
-                selectByMouse: true
-                font.pointSize: Constants.largePointSize
-                font.family: Constants.genericTable.fontFamily
-                anchors.fill: parent
-                anchors.leftMargin: Constants.updateTab.firmwareVersionElementsLabelRightMargin
-                onTextEdited: {
-                    localFileTextEditing = true;
-                }
-                onEditingFinished: {
-                    let downloadLatestFirmware = false;
-                    let updateFirmware = false;
-                    let sendFileToDevice = false;
-                    let serialPromptConfirm = false;
-                    let updateLocalFilepath = null;
-                    let downloadDirectory = null;
-                    let fileioLocalFilepath = null;
-                    let fileioDestinationFilepath = null;
-                    let updateLocalFilename = text;
-                    data_model.update_tab([downloadLatestFirmware, updateFirmware, sendFileToDevice, serialPromptConfirm], updateLocalFilepath, downloadDirectory, fileioLocalFilepath, fileioDestinationFilepath, updateLocalFilename);
-                    localFileTextEditing = false;
-                }
-
-                Label {
-                    text: Constants.updateTab.firmwareVersionLocalFilePlaceholderText
-                    color: Constants.loggingBar.placeholderTextColor
-                    visible: !localFileTextInput.text
-                    anchors.fill: parent
-                    anchors.leftMargin: Constants.updateTab.firmwareVersionElementsLabelRightMargin
-                    anchors.centerIn: parent
-                }
-
+            onTextEdited: {
+                localFileTextEditing = true;
             }
-
+            onEditingFinished: {
+                let downloadLatestFirmware = false;
+                let updateFirmware = false;
+                let sendFileToDevice = false;
+                let serialPromptConfirm = false;
+                let updateLocalFilepath = null;
+                let downloadDirectory = null;
+                let fileioLocalFilepath = null;
+                let fileioDestinationFilepath = null;
+                let updateLocalFilename = text;
+                data_model.update_tab([downloadLatestFirmware, updateFirmware, sendFileToDevice, serialPromptConfirm], updateLocalFilepath, downloadDirectory, fileioLocalFilepath, fileioDestinationFilepath, updateLocalFilename);
+                localFileTextEditing = false;
+            }
         }
 
         Item {
@@ -90,6 +62,8 @@ Item {
             Label {
                 text: Constants.updateTab.dotDotDotLabel
                 anchors.centerIn: parent
+                font.family: Constants.genericTable.fontFamily
+                font.pointSize: Constants.largePointSize
             }
 
         }

--- a/resources/console_resources.qrc
+++ b/resources/console_resources.qrc
@@ -112,6 +112,8 @@
     <file>BaseComponents/SwiftButton.qml</file>
     <file>BaseComponents/SwiftValueAxis.qml</file>
     <file>BaseComponents/SwiftCategoryAxis.qml</file>
+    <file>BaseComponents/SwiftTextbox.qml</file>
+    <file>BaseComponents/SwiftTextInput.qml</file>
     <file>ChartLegend.qml</file>
     <file alias="SwiftNav/TabBar.qml">styles/SwiftNav/TabBar.qml</file>
     <file alias="SwiftNav/TabButton.qml">styles/SwiftNav/TabButton.qml</file>


### PR DESCRIPTION
* Makes a SwiftTextbox and SwiftTextInput type to standardize and abstract most of the formatting.
* Everything else is mostly just converting all text boxes and text inputs to these abstract types.

Comparison below: New vs Old
![Screen Shot 2022-01-11 at 11 15 27 AM](https://user-images.githubusercontent.com/43353147/149008641-9f9647b0-9fa7-4316-b591-30117d327868.png)
