### PR TITLE
Checkbox colour orange -> grey [CPP-433]

### DIFF
--- a/resources/BaseComponents/SmallCheckBox.qml
+++ b/resources/BaseComponents/SmallCheckBox.qml
@@ -30,7 +30,7 @@ T.CheckBox {
         x: control.text ? (control.mirrored ? control.width - width - control.rightPadding : control.leftPadding) : control.leftPadding + (control.availableWidth - width) / 2
         y: control.topPadding + (control.availableHeight - height) / 2
         control: control
-        border.color: !control.enabled ? control.Material.hintTextColor : control.Material.secondaryTextColor
+        border.color: !control.enabled ? control.Material.hintTextColor : Color.blend(Constants.sideNavBar.backgroundColor, control.palette.mid, control.checked ? 0.5 : 0)
 
         Ripple {
             x: (parent.width - width) / 2


### PR DESCRIPTION
Looks like this

<img width="353" alt="Screen Shot 2022-01-13 at 5 38 43 pm" src="https://user-images.githubusercontent.com/26106369/149278789-e9348652-79d0-47b2-ba50-d22ab9e7c4ff.png">

[This](https://github.com/qt/qtquickcontrols2/blob/v5.12.12/src/imports/controls/material/CheckIndicator.qml#L46)  is what is being overridden.