### PR TITLE
Point to custom serialport dependency with COMMTIMEOUTS[CPP-553]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1649,7 +1649,7 @@ dependencies = [
 [[package]]
 name = "serialport"
 version = "4.0.2-alpha.0"
-source = "git+https://gitlab.com/john-michaelburke/serialport-rs.git?branch=john-michaelburke/commtimeouts#8e117b07d9edcff507b76d57f59504855bdf1de3"
+source = "git+https://github.com/swift-nav/serialport-rs.git#875f545b937035dbc5dcdf454dd0460bc8d0bd3d"
 dependencies = [
  "CoreFoundation-sys",
  "IOKit-sys",

--- a/console_backend/Cargo.toml
+++ b/console_backend/Cargo.toml
@@ -27,7 +27,7 @@ ndarray = "0.15.4"
 glob = "0.3.0"
 criterion = "0.3.4"
 sysinfo = "0.23.0"
-serialport = { git = "https://gitlab.com/john-michaelburke/serialport-rs.git", branch = "john-michaelburke/commtimeouts", default-features = false }
+serialport = { git = "https://github.com/swift-nav/serialport-rs.git", default-features = false }
 directories = "4"
 anyhow = { version = "1", features = ["backtrace"] }
 serde_yaml = "0.8.23"
@@ -47,7 +47,7 @@ mimalloc = { version = "0.1", default-features = false }
 curl = { version = "0.4", features = ["ssl", "static-curl"] }
 
 [target.'cfg(any(target_os = "macos", target_os = "windows"))'.dependencies]
-serialport = { git = "https://gitlab.com/john-michaelburke/serialport-rs.git", branch = "john-michaelburke/commtimeouts" }
+serialport = { git = "https://github.com/swift-nav/serialport-rs.git" }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = ">=0.24", features = [


### PR DESCRIPTION
On Windows serial connections will now finish a read the moment data becomes available instead of when the timeout expires, this behavior is now inline with the behavior observed on unix serial connections.
Points to a branch implementing this fix temporarily until it gets merged to master (I added a comment asking for an update):
https://gitlab.com/susurrus/serialport-rs/-/merge_requests/78

It appears the original maintainer has been trying to find a new maintainer over the past year. This fix seems to be high on the list of desired fixes in the community so fingers crossed.
https://gitlab.com/susurrus/serialport-rs/-/issues/111