### PR TITLE
Default TCP/IP Host+Port[CPP-581]

### DIFF
--- a/console_backend/src/constants.rs
+++ b/console_backend/src/constants.rs
@@ -20,6 +20,8 @@ pub(crate) const BASELINE_TIME_STR_FILEPATH: &str = "baseline_log_%Y%m%d-%H%M%S.
 pub(crate) const SBP_FILEPATH: &str = "swift-gnss-%Y%m%d-%H%M%S.sbp";
 pub(crate) const SBP_JSON_FILEPATH: &str = "swift-gnss-%Y%m%d-%H%M%S.sbp.json";
 pub(crate) const DEFAULT_LOG_DIRECTORY: &str = "SwiftNav";
+pub(crate) const DEFAULT_IP_ADDRESS: &str = "192.168.0.222";
+pub(crate) const DEFAULT_PORT: u16 = 55555;
 
 // Common constants.
 pub(crate) const NUM_POINTS: usize = 200;

--- a/console_backend/src/shared_state.rs
+++ b/console_backend/src/shared_state.rs
@@ -24,7 +24,7 @@ use serialport::FlowControl;
 
 use crate::constants::{
     APPLICATION_NAME, APPLICATION_ORGANIZATION, APPLICATION_QUALIFIER, CONNECTION_HISTORY_FILENAME,
-    DEFAULT_LOG_DIRECTORY, MAX_CONNECTION_HISTORY, MPS,
+    DEFAULT_IP_ADDRESS, DEFAULT_LOG_DIRECTORY, DEFAULT_PORT, MAX_CONNECTION_HISTORY, MPS,
 };
 use crate::errors::CONVERT_TO_STR_FAILURE;
 use crate::log_panel::LogLevel;
@@ -758,8 +758,13 @@ impl ConnectionHistory {
         if let Ok(default_path) = LOG_DIRECTORY.path().into_os_string().into_string() {
             folders.insert(default_path);
         }
+        let mut addresses = IndexSet::new();
+        addresses.insert(Address {
+            host: DEFAULT_IP_ADDRESS.to_string(),
+            port: DEFAULT_PORT,
+        });
         ConnectionHistory {
-            addresses: IndexSet::new(),
+            addresses,
             files: IndexSet::new(),
             folders,
             serial_configs: IndexMap::new(),
@@ -961,9 +966,9 @@ mod tests {
         backup_file(bfilename.clone());
 
         let mut conn_history = ConnectionHistory::new();
-        let host1 = String::from("host1");
+        let host1 = String::from(DEFAULT_IP_ADDRESS);
         let host2 = String::from("host2");
-        let port = 100;
+        let port = DEFAULT_PORT;
 
         conn_history.record_address(host1.clone(), port);
         let addresses = conn_history.addresses();

--- a/swiftnav_console/main.py
+++ b/swiftnav_console/main.py
@@ -154,7 +154,7 @@ from .file_io import FileIO
 
 CONSOLE_BACKEND_CAPNP_PATH = "console_backend.capnp"
 
-PIKSI_HOST = "piksi-relay-bb9f2b10e53143f4a816a11884e679cf.ce.swiftnav.com"
+PIKSI_HOST = "192.168.0.222"
 PIKSI_PORT = 55555
 
 


### PR DESCRIPTION
If no connection_history.yaml file is found on the system, indicative of a new user, add default tcp and default port to pending connection_history.yaml. Upon successful connection to this port/ip or any other port/ip, the default will get saved to the file.

Also changed our hidden connection to the piksi relay to point to the default ip instead.