### PR TITLE
Fix satellite miscounts [CPP-600]

### DIFF
--- a/swiftnav_console/observation_tab.py
+++ b/swiftnav_console/observation_tab.py
@@ -245,7 +245,8 @@ class ObservationTableModel(QAbstractTableModel):  # pylint: disable=too-many-pu
     gal_codes = Property(QTKeys.QVARIANTLIST, get_gal_codes, notify=codes_changed)  # type: ignore
     qzs_codes = Property(QTKeys.QVARIANTLIST, get_qzs_codes, notify=codes_changed)  # type: ignore
     sbas_codes = Property(QTKeys.QVARIANTLIST, get_sbas_codes, notify=codes_changed)  # type: ignore
-    codes = Property(QTKeys.QVARIANTLIST, get_codes, notify=codes_changed)  # type: ignore
+    # Confusingly, codes depends on self._rows not self._codes
+    codes = Property(QTKeys.QVARIANTLIST, get_codes, notify=row_count_changed)  # type: ignore
 
 
 def obs_rows_to_json(rows):


### PR DESCRIPTION
The QT property `ObservationTableModel.codes` actually depends on `ObservationTableModel._rows`, not `ObservationTableModel._codes`.  Sometimes when the rows were updated, this meant that no signal was sent that `codes` had changed.  This meant that we sometimes were displaying the wrong number of satellites in each constellation.

It is most easy to see the satellite miscounts by switching between different devices over TCP eg `10.1.54.4` and `10.1.54.2`.