### PR TITLE
Add label to frontend benchmark stage.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -386,7 +386,7 @@ jobs:
           - macOS
           - Windows
           - Linux
-    runs-on: [self-hosted, '${{ matrix.os }}']
+    runs-on: [self-hosted, '${{ matrix.os }}', bench]
     steps:
       - name: Remove previous build.
         shell: bash


### PR DESCRIPTION
To prepare for running our Windows installer on the code signer runner, we need to refine our labelling for the machines available to the frontend benchmark stage. I also added labels to the bench machines accordingly.