### PR TITLE
Parse tcp subcommand for host/port pair[CPP-637]

### DIFF
--- a/console_backend/src/cli_options.rs
+++ b/console_backend/src/cli_options.rs
@@ -215,7 +215,7 @@ pub enum Input {
         flow_control: FlowControl,
     },
     Tcp {
-        /// The TCP host to connect to.
+        /// The TCP/IP host or TCP/IP host-port pair to connect with. For example: "192.168.0.222" or "192.168.0.222:55555"
         host: String,
 
         /// The port to use when connecting via TCP.

--- a/console_backend/src/connection.rs
+++ b/console_backend/src/connection.rs
@@ -55,6 +55,12 @@ impl ConnectionManager {
     /// - `host`: The host portion of the TCP stream to open.
     /// - `port`: The port to be used to open a TCP stream.
     pub fn connect_to_host(&self, host: String, port: u16) -> Result<()> {
+        let host_split: Vec<&str> = host.split(':').collect();
+        let (host, port) = if host_split.len() == 2 {
+            (host_split[0].to_string(), host_split[1].parse::<u16>()?)
+        } else {
+            (host, port)
+        };
         let conn = Connection::tcp(host, port)?;
         self.msg.send(ConnectionManagerMsg::Connect(conn));
         Ok(())


### PR DESCRIPTION
* Parse the TCP/IP subcommand for an optional format "host" or "host:port". If the latter is provided it would override any port provided via the port argument.
* Also parse the arguments for help related args to prevent loading the qml app if help is requested.

Here is what the CLI looks like for TCP/IP now:
<img width="1230" alt="Screen Shot 2022-02-03 at 6 11 54 PM" src="https://user-images.githubusercontent.com/43353147/152461029-ee6f5ccb-6acc-48ea-9a95-805c630f986a.png">

