### PR TITLE
Mac Installer Signed+Notarized[CPP-647]

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,7 @@ env:
   CARGO_INCREMENTAL: 0
   RUSTFLAGS: "-C debuginfo=0"
   APP_NAME: swift-console
+  APP_BUNDLE_ID: com.swift-nav.SwiftConsole
 
 jobs:
 
@@ -302,7 +303,7 @@ jobs:
           fi
           echo $INSTALLER_ARCHIVE >installer-archive.filename
           echo "INSTALLER_ARCHIVE=$(cat installer-archive.filename)" >>$GITHUB_ENV
-        if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
+        if: github.event_name == 'push' && contains(github.ref, 'refs/tags') && matrix.os.name != 'macos-10.15'
 
       - name: Build ${{ runner.os }} swift-files binary.
         run: |
@@ -351,6 +352,13 @@ jobs:
           path: ./target/release/swift-settings${{ matrix.os.exe_suffix }}
       - uses: actions/upload-artifact@v2
         with:
+          name: ${{ runner.os }}-installer
+          path: |
+            ${{ env.INSTALLER_ARCHIVE }}
+            installer-archive.filename
+        if: github.event_name == 'push' && contains(github.ref, 'refs/tags') && matrix.os.name != 'macos-10.15'
+      - uses: actions/upload-artifact@v2
+        with:
           name: ${{ runner.os }}-artifacts-debug
           path: |
             ${{ env.DEBUG_ARCHIVE }}
@@ -367,13 +375,98 @@ jobs:
         shell: bash
         run: |
           cargo make disk-usage-bench
+
+  sign_application:
+    name: Sign Application
+    timeout-minutes: 30
+    needs:
+      - build
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
+    strategy:
+      matrix:
+        os:
+          - macOS
+    runs-on: [self-hosted, '${{ matrix.os }}', code-signer]
+    steps:
+
+      - name: Remove previous build.
+        shell: bash
+        continue-on-error: true
+        run: |
+          rm -rf application
+
+      - name: Checkout source.
+        uses: actions/checkout@v2
+        with:
+          path: application
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: ${{ matrix.os }}-artifacts
+          path: |
+            application
+
+      - name: Unzip release artifact.
+        shell: bash
+        run: |
+          cd application
+          mkdir -p py39-dist
+          tar -xvf "$(cat release-archive.filename)" -C py39-dist
+
+      - name: Build .app bundle.
+        shell: bash
+        run: |
+          cd application
+          cargo make dist-to-installer-app
+      
+      - name: Sign application.
+        shell: bash
+        run: |
+          cd "application/target/installer/Swift Console.app"
+          for f in $(find Contents/Resources/lib/ -name '*.dylib' -or -name '*.so')
+          do 
+            codesign \
+            -s "${{ secrets.APPLE_DEVELOPER_ID }}" \
+            --timestamp \
+            "$f"
+          done
+
+          for f in $(ls Contents/Resources/lib/python3.9/site-packages/PySide2/Qt/lib/*.framework/Versions/5/*)
+          do
+            codesign \
+              -s "${{ secrets.APPLE_DEVELOPER_ID }}" \
+              --timestamp \
+              "$f"
+          done
+
+          cd ../../../
+          codesign \
+            -s "${{ secrets.APPLE_DEVELOPER_ID }}" --deep \
+            --entitlements installers/macOS/entitlements.plist \
+            --timestamp \
+            --options=runtime \
+            "target/installer/Swift Console.app"
+
+      - name: Build dmg file.
+        shell: bash
+        run: |
+          cd application
+          cargo make store-version
+          cargo make dist-to-installer-dmg
+
+      - name: Add archive to path.
+        shell: bash
+        run: |
+          INSTALLER_ARCHIVE=$(find application -iname "*.dmg")
+          echo $INSTALLER_ARCHIVE >installer-archive.filename
+          echo "INSTALLER_ARCHIVE=$(cat installer-archive.filename)" >>$GITHUB_ENV
+
       - uses: actions/upload-artifact@v2
         with:
           name: ${{ runner.os }}-installer
           path: |
             ${{ env.INSTALLER_ARCHIVE }}
             installer-archive.filename
-        if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
 
   frontend_bench:
     name: Run Frontend Benchmarks
@@ -460,33 +553,68 @@ jobs:
     name: Sign Installers
     timeout-minutes: 30
     needs:
+      - sign_application
       - frontend_bench
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
     strategy:
       matrix:
         os:
           - Windows
+          - macOS
     runs-on: [self-hosted, '${{ matrix.os }}', code-signer]
     steps:
 
       - name: Remove previous build.
         shell: bash
+        continue-on-error: true
         run: |
-          rm -r *
+          rm -rf installer
 
       - uses: actions/download-artifact@v2
         with:
           name: ${{ matrix.os }}-installer
+          path: |
+            installer
 
       - name: Sign Installer.
         shell: cmd
         run: |
+          cd installer
           set /p executable=<installer-archive.filename
-          "${{ env.CODE_SIGNER_PATH_WIN }}" sign /debug /v /n "Swift Navigation, Inc." /a /tr http://rfc3161timestamp.globalsign.com/advanced /td SHA256 %executable%
+          "${{ env.CODE_SIGNER_PATH_WIN }}" sign ^
+            /debug /v ^
+            /n "Swift Navigation, Inc." /a ^
+            /tr http://rfc3161timestamp.globalsign.com/advanced ^
+            /td SHA256 %executable%
+        if: matrix.os == 'Windows'
+
+      - name: Sign Installer.
+        shell: bash
+        run: |
+          cd installer
+          codesign \
+            -s "${{ secrets.APPLE_DEVELOPER_ID }}" \
+            -f --timestamp \
+            $(cat installer-archive.filename)
+          xcrun altool \
+            --notarize-app \
+            --file $(cat installer-archive.filename) \
+            --primary-bundle-id ${{ env.APP_BUNDLE_ID }} \
+            --apiKey ${{ secrets.APPLE_KEY_ID }} \
+            --apiIssuer ${{ secrets.APPLE_ISSUER_ID }}
+        if: matrix.os == 'macOS'
 
       - name: Add archive to path.
         shell: bash
         run: |
+          if [ "$RUNNER_OS" == "Linux" ]; then
+              INSTALLER_ARCHIVE=$(find installer -iname "*.deb")
+          elif [ "$RUNNER_OS" == "Windows" ]; then
+              INSTALLER_ARCHIVE=$(ls installer/installers/Windows/*.exe)
+          elif [ "$RUNNER_OS" == "macOS" ]; then
+              INSTALLER_ARCHIVE=$(find installer -iname "*.dmg")
+          fi
+          echo $INSTALLER_ARCHIVE >installer-archive.filename
           echo "INSTALLER_ARCHIVE=$(cat installer-archive.filename)" >>$GITHUB_ENV
 
       - uses: actions/upload-artifact@v2

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -456,11 +456,11 @@ if eq ${os} windows
 else
     rm -r ./share
 
-    bins = array rcc uic designer
+    bins = array rcc uic designer pyside2-lupdate Designer.app
     for bin in ${bins}
         files = glob_array ./**/PySide2/${bin}
         for bin in ${files}
-            rm ${bin}
+            rm -r ${bin}
         end
     end
 end
@@ -579,7 +579,8 @@ set_env ICNS_PATH "installers/macOS/icon.icns"
 set_env BACKGROUND_PATH "resources/images/LogoBackground.jpg"
 '''
 
-[tasks.dist-to-installer.mac]
+[tasks.dist-to-installer-app]
+[tasks.dist-to-installer-app.mac]
 dependencies = ["dist-to-installer-env"]
 script_runner = "@duckscript"
 script = '''
@@ -595,11 +596,35 @@ contents_resources_dir = get_env CONTENTS_RESOURCES_DIR
 contents_resources_dir = set ${contents_dir}/${contents_resources_dir}
 info_plist_path = get_env INFO_PLIST_PATH
 icns_path = get_env ICNS_PATH
-background_path = get_env BACKGROUND_PATH
 
 if is_path_exists ${tmp_dir}
   rm -r ${tmp_dir}
 end
+
+mkdir ${contents_dir}
+mkdir ${contents_mac_os}
+exec --fail-on-error cp -r py39-dist "${contents_resources_dir}"
+exec --fail-on-error mv ./${contents_resources_dir}/${app_original_name} "./${contents_mac_os}/${app_file_prefix}"
+exec --fail-on-error ln -s "../Resources/lib" ${contents_mac_os}/lib
+exec --fail-on-error ln -s "../Resources/.frozen" ${contents_mac_os}/.frozen
+exec --fail-on-error ln -s "../Resources/resources" ${contents_mac_os}/resources
+cp ./${info_plist_path} ./${contents_dir}/Info.plist
+mkdir ${contents_resources_dir}
+cp ${icns_path} ./${contents_resources_dir}/${app_file_prefix}.icns
+'''
+
+[tasks.dist-to-installer-dmg]
+[tasks.dist-to-installer-dmg.mac]
+dependencies = ["dist-to-installer-env"]
+script_runner = "@duckscript"
+script = '''
+final_dir = get_env FINAL_DIR
+tmp_dir = get_env TMP_DIR
+app_original_name = get_env APP_ORIGINAL_NAME
+app_file_prefix = get_env APP_FILE_PREFIX
+app_dir_name = set "${app_file_prefix}.app"
+icns_path = get_env ICNS_PATH
+background_path = get_env BACKGROUND_PATH
 
 version_path = get_env VERSION_PATH
 version = readfile ${version_path}
@@ -607,18 +632,15 @@ version = trim_end ${version}
 dmg_path = set ./${final_dir}/${app_original_name}_${version}_macos.dmg
 
 old_dmgs = glob_array "./${final_dir}/*.dmg"
-for dmg_path in ${old_dmgs}
-    rm ${dmg_path}
+for path in ${old_dmgs}
+    rm ${path}
 end
 
-mkdir ${contents_dir}
-exec --fail-on-error cp -r py39-dist "${contents_mac_os}"
-exec --fail-on-error mv ./${contents_mac_os}/${app_original_name} "./${contents_mac_os}/${app_file_prefix}"
-cp ./${info_plist_path} ./${contents_dir}/Info.plist
-mkdir ${contents_resources_dir}
-cp ${icns_path} ./${contents_resources_dir}/${app_file_prefix}.icns
 exec --fail-on-error create-dmg --volname "${app_file_prefix}" --volicon "${icns_path}" --background "${background_path}" --hdiutil-verbose --window-pos 200 120 --window-size 800 400 --icon-size 100 --icon "${app_dir_name}" 200 190 --hide-extension "${app_dir_name}" --app-drop-link 600 185 "${dmg_path}" "${tmp_dir}"
 '''
+
+[tasks.dist-to-installer.mac]
+dependencies = ["dist-to-installer-app", "dist-to-installer-dmg"]
 
 [tasks.dist-to-installer-env.linux]
 script_runner = "@duckscript"

--- a/installers/macOS/entitlements.plist
+++ b/installers/macOS/entitlements.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+  </dict>
+</plist>


### PR DESCRIPTION
* Breaks up the dist-to-installer function for mac to allow signing between creation of ".app" and ".dmg".
* Adds a stage, "sign_application", between "build" and "sign_installer" that runs parallel to "frontend_bench". This stage creates ".app", signs the necessary files and then creates the dmg.
* Added mac to the "sign_installer" matrix to sign and notarize the dmg produced in "sign_application". 