### PR TITLE
Set up release of mac tools

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -310,7 +310,7 @@ jobs:
 
       - name: Build ${{ runner.os }} swift-settings binary.
         run: |
-          cargo build --release --bin swift-settings --features env_logger
+          cargo build --release --bin swift-settings --no-default-features --features env_logger
 
       - name: Pull Git LFS objects
         run: git lfs pull


### PR DESCRIPTION
Just missing the `--no-default-features` flag to skip building pyo3