### PR TITLE
AdvSysMon UI rework, Solution/Baseline pause-clear[CPP-512][CPP-514][CPP-523]

### DIFF
--- a/console_backend/src/baseline_tab.rs
+++ b/console_backend/src/baseline_tab.rs
@@ -426,8 +426,7 @@ impl BaselineTab {
     fn solution_draw(&mut self, buttons: BaselineTabButtons) {
         if buttons.clear {
             self.clear_sln();
-        }
-        if buttons.pause {
+        } else if buttons.pause {
             return;
         }
         if buttons.reset {

--- a/console_backend/src/solution_tab.rs
+++ b/console_backend/src/solution_tab.rs
@@ -648,8 +648,7 @@ impl SolutionTab {
     pub fn solution_draw(&mut self, clear: bool, pause: bool) {
         if clear {
             self.clear_sln();
-        }
-        if pause {
+        } else if pause {
             return;
         }
         let current_mode: Option<String> = if !self.pending_draw_modes.is_empty() {

--- a/resources/AdvancedTabComponents/AdvancedSystemMonitorTab.qml
+++ b/resources/AdvancedTabComponents/AdvancedSystemMonitorTab.qml
@@ -12,64 +12,30 @@ Item {
         id: advancedSystemMonitorData
     }
 
-    GridLayout {
+    RowLayout {
         id: gridLayout
 
-        rows: Constants.systemMonitor.rows
-        columns: Constants.systemMonitor.columns
-        rowSpacing: Constants.systemMonitor.rowSpacing
-        columnSpacing: Constants.systemMonitor.columnSpacing
         anchors.fill: parent
+
+        AdvancedSystemMonitorTabLeftPane {
+            id: leftPane
+
+            Layout.minimumWidth: parent.width / 2
+            Layout.fillHeight: true
+        }
 
         ThreadStateTable {
             id: threadStateTable
 
             Layout.fillHeight: true
             Layout.fillWidth: true
-            Layout.columnSpan: Constants.systemMonitor.columns
-            Layout.rowSpan: Constants.systemMonitor.topRowSpan
-            Layout.preferredHeight: Constants.systemMonitor.topRowSpan
-            Layout.preferredWidth: Constants.systemMonitor.columns
-        }
-
-        ObservationConnectionMonitor {
-            id: observationConnectionMonitor
-
-            Layout.fillHeight: true
-            Layout.fillWidth: true
-            Layout.columnSpan: Constants.systemMonitor.observationConnectionMonitorColumnSpan
-            Layout.rowSpan: Constants.systemMonitor.bottomRowSpan
-            Layout.preferredHeight: Constants.systemMonitor.bottomRowSpan
-            Layout.preferredWidth: Constants.systemMonitor.observationConnectionMonitorColumnSpan
-        }
-
-        DeviceMonitor {
-            id: deviceMonitor
-
-            Layout.fillHeight: true
-            Layout.fillWidth: true
-            Layout.columnSpan: Constants.systemMonitor.deviceMonitorColumnSpan
-            Layout.rowSpan: Constants.systemMonitor.bottomRowSpan
-            Layout.preferredHeight: Constants.systemMonitor.bottomRowSpan
-            Layout.preferredWidth: Constants.systemMonitor.deviceMonitorColumnSpan
-        }
-
-        MetricsMonitor {
-            id: metricsMonitor
-
-            Layout.fillHeight: true
-            Layout.fillWidth: true
-            Layout.columnSpan: Constants.systemMonitor.metricsMonitorColumnSpan
-            Layout.rowSpan: Constants.systemMonitor.bottomRowSpan
-            Layout.preferredHeight: Constants.systemMonitor.bottomRowSpan
-            Layout.preferredWidth: Constants.systemMonitor.metricsMonitorColumnSpan
         }
 
     }
 
     Timer {
         interval: Utils.hzToMilliseconds(Constants.staticTableTimerIntervalRate)
-        running: true
+        running: advancedSystemMonitorTab.visible
         repeat: true
         onTriggered: {
             if (!advancedTab.visible)
@@ -80,19 +46,19 @@ Item {
                 return ;
 
             threadStateTable.entries = advancedSystemMonitorData.threads_table;
-            observationConnectionMonitor.obsPeriod[advancedSystemMonitorData.obs_period[0][0]] = advancedSystemMonitorData.obs_period[0][1];
-            observationConnectionMonitor.obsPeriod[advancedSystemMonitorData.obs_period[1][0]] = advancedSystemMonitorData.obs_period[1][1];
-            observationConnectionMonitor.obsPeriod[advancedSystemMonitorData.obs_period[2][0]] = advancedSystemMonitorData.obs_period[2][1];
-            observationConnectionMonitor.obsPeriod[advancedSystemMonitorData.obs_period[3][0]] = advancedSystemMonitorData.obs_period[3][1];
-            observationConnectionMonitor.obsLatency[advancedSystemMonitorData.obs_latency[0][0]] = advancedSystemMonitorData.obs_latency[0][1];
-            observationConnectionMonitor.obsLatency[advancedSystemMonitorData.obs_latency[1][0]] = advancedSystemMonitorData.obs_latency[1][1];
-            observationConnectionMonitor.obsLatency[advancedSystemMonitorData.obs_latency[2][0]] = advancedSystemMonitorData.obs_latency[2][1];
-            observationConnectionMonitor.obsLatency[advancedSystemMonitorData.obs_latency[3][0]] = advancedSystemMonitorData.obs_latency[3][1];
-            observationConnectionMonitor.obsLatency[advancedSystemMonitorData.obs_latency[3][0]] = advancedSystemMonitorData.obs_latency[3][1];
-            metricsMonitor.entries = advancedSystemMonitorData.csac_telem_list;
-            metricsMonitor.csacReceived = advancedSystemMonitorData.csac_received;
-            deviceMonitor.zynqTemp = advancedSystemMonitorData.zynq_temp;
-            deviceMonitor.feTemp = advancedSystemMonitorData.fe_temp;
+            leftPane.observationConnectionMonitor.obsPeriod[advancedSystemMonitorData.obs_period[0][0]] = advancedSystemMonitorData.obs_period[0][1];
+            leftPane.observationConnectionMonitor.obsPeriod[advancedSystemMonitorData.obs_period[1][0]] = advancedSystemMonitorData.obs_period[1][1];
+            leftPane.observationConnectionMonitor.obsPeriod[advancedSystemMonitorData.obs_period[2][0]] = advancedSystemMonitorData.obs_period[2][1];
+            leftPane.observationConnectionMonitor.obsPeriod[advancedSystemMonitorData.obs_period[3][0]] = advancedSystemMonitorData.obs_period[3][1];
+            leftPane.observationConnectionMonitor.obsLatency[advancedSystemMonitorData.obs_latency[0][0]] = advancedSystemMonitorData.obs_latency[0][1];
+            leftPane.observationConnectionMonitor.obsLatency[advancedSystemMonitorData.obs_latency[1][0]] = advancedSystemMonitorData.obs_latency[1][1];
+            leftPane.observationConnectionMonitor.obsLatency[advancedSystemMonitorData.obs_latency[2][0]] = advancedSystemMonitorData.obs_latency[2][1];
+            leftPane.observationConnectionMonitor.obsLatency[advancedSystemMonitorData.obs_latency[3][0]] = advancedSystemMonitorData.obs_latency[3][1];
+            leftPane.observationConnectionMonitor.obsLatency[advancedSystemMonitorData.obs_latency[3][0]] = advancedSystemMonitorData.obs_latency[3][1];
+            leftPane.metricsMonitor.entries = advancedSystemMonitorData.csac_telem_list;
+            leftPane.metricsMonitor.csacReceived = advancedSystemMonitorData.csac_received;
+            leftPane.deviceMonitor.zynqTemp = advancedSystemMonitorData.zynq_temp;
+            leftPane.deviceMonitor.feTemp = advancedSystemMonitorData.fe_temp;
         }
     }
 

--- a/resources/AdvancedTabComponents/AdvancedSystemMonitorTabLeftPane.qml
+++ b/resources/AdvancedTabComponents/AdvancedSystemMonitorTabLeftPane.qml
@@ -1,0 +1,42 @@
+import "../BaseComponents"
+import "../Constants"
+import QtCharts 2.3
+import QtQuick 2.6
+import QtQuick.Controls 2.12
+import QtQuick.Layouts 1.15
+import SwiftConsole 1.0
+
+Item {
+    property alias observationConnectionMonitor: observationConnectionMonitor
+    property alias deviceMonitor: deviceMonitorAndResetDevice.deviceMonitor
+    property alias metricsMonitor: metricsMonitor
+
+    ColumnLayout {
+        id: gridLayout
+
+        anchors.fill: parent
+
+        DeviceMonitorAndResetDevice {
+            id: deviceMonitorAndResetDevice
+
+            Layout.fillWidth: true
+            Layout.preferredHeight: parent.height * 0.25
+        }
+
+        ObservationConnectionMonitor {
+            id: observationConnectionMonitor
+
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+        }
+
+        MetricsMonitor {
+            id: metricsMonitor
+
+            visible: false
+            enabled: false
+        }
+
+    }
+
+}

--- a/resources/AdvancedTabComponents/DeviceMonitorAndResetDevice.qml
+++ b/resources/AdvancedTabComponents/DeviceMonitorAndResetDevice.qml
@@ -1,0 +1,42 @@
+import "../BaseComponents"
+import "../Constants"
+import QtCharts 2.3
+import QtQuick 2.6
+import QtQuick.Controls 2.12
+import QtQuick.Layouts 1.15
+import SwiftConsole 1.0
+
+Item {
+    property alias deviceMonitor: deviceMonitor
+
+    RowLayout {
+        anchors.fill: parent
+
+        DeviceMonitor {
+            id: deviceMonitor
+
+            Layout.preferredWidth: parent.width * 0.5
+            Layout.fillHeight: true
+        }
+
+        SwiftButton {
+            id: resetButton
+
+            Layout.preferredWidth: parent.width * 0.5
+            Layout.alignment: Qt.AlignHCenter
+            ToolTip.visible: hovered
+            ToolTip.text: Constants.systemMonitor.resetButtonLabel
+            text: Constants.systemMonitor.resetButtonLabel
+            icon.source: Constants.icons.connectButtonPath
+            icon.width: Constants.systemMonitor.resetButtonIconSideLength
+            icon.height: Constants.systemMonitor.resetButtonIconSideLength
+            display: AbstractButton.TextUnderIcon
+            flat: true
+            onClicked: {
+                data_model.reset_device();
+            }
+        }
+
+    }
+
+}

--- a/resources/AdvancedTabComponents/ObservationConnectionMonitor.qml
+++ b/resources/AdvancedTabComponents/ObservationConnectionMonitor.qml
@@ -137,22 +137,6 @@ Item {
 
         }
 
-        SwiftButton {
-            id: resetButton
-
-            ToolTip.visible: hovered
-            ToolTip.text: Constants.systemMonitor.resetButtonLabel
-            text: Constants.systemMonitor.resetButtonLabel
-            icon.source: Constants.icons.connectButtonPath
-            icon.width: Constants.systemMonitor.resetButtonIconSideLength
-            icon.height: Constants.systemMonitor.resetButtonIconSideLength
-            display: AbstractButton.TextUnderIcon
-            flat: true
-            onClicked: {
-                data_model.reset_device();
-            }
-        }
-
     }
 
 }

--- a/resources/AdvancedTabComponents/ThreadStateTable.qml
+++ b/resources/AdvancedTabComponents/ThreadStateTable.qml
@@ -8,7 +8,6 @@ import QtQuick.Layouts 1.15
 import SwiftConsole 1.0
 
 Item {
-    property variant columnWidths: [parent.width / 3, parent.width / 3, parent.width / 3]
     property real mouse_x: 0
     property variant entries: []
 
@@ -20,7 +19,7 @@ Item {
         z: Constants.genericTable.headerZOffset
 
         delegate: Rectangle {
-            implicitWidth: columnWidths[index]
+            implicitWidth: tableView.columnWidths[index]
             implicitHeight: Constants.genericTable.cellHeight
             border.color: Constants.genericTable.borderColor
 
@@ -49,9 +48,9 @@ Item {
                         var delta_x = (mouseX - mouse_x);
                         var next_idx = (index + 1) % 3;
                         var min_width = tableView.width / 6;
-                        if (columnWidths[index] + delta_x > min_width && columnWidths[next_idx] - delta_x > min_width) {
-                            columnWidths[index] += delta_x;
-                            columnWidths[next_idx] -= delta_x;
+                        if (tableView.columnWidths[index] + delta_x > min_width && tableView.columnWidths[next_idx] - delta_x > min_width) {
+                            tableView.columnWidths[index] += delta_x;
+                            tableView.columnWidths[next_idx] -= delta_x;
                         }
                         tableView.forceLayout();
                     }
@@ -82,7 +81,7 @@ Item {
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.bottom: parent.bottom
-        columnWidths: parent.columnWidths
+        columnWidths: [parent.width / 3, parent.width / 3, parent.width / 3]
 
         model: TableModel {
             id: tableModel

--- a/resources/console_resources.qrc
+++ b/resources/console_resources.qrc
@@ -25,8 +25,10 @@
     <file>AdvancedTab.qml</file>
     <file>ConnectionScreen.qml</file>
     <file>AdvancedTabComponents/AdvancedSystemMonitorTab.qml</file>
+    <file>AdvancedTabComponents/AdvancedSystemMonitorTabLeftPane.qml</file>
     <file>AdvancedTabComponents/ThreadStateTable.qml</file>
     <file>AdvancedTabComponents/DeviceMonitor.qml</file>
+    <file>AdvancedTabComponents/DeviceMonitorAndResetDevice.qml</file>
     <file>AdvancedTabComponents/MetricsMonitor.qml</file>
     <file>AdvancedTabComponents/ObservationConnectionMonitor.qml</file>
     <file>AdvancedTabComponents/AdvancedImuTab.qml</file>


### PR DESCRIPTION
* Minor redesign of the System Monitor Tab. Making the CSAC Metrics Table disabled if there is ever a reason to revive it. Nothing else really changed just moved things around and connected the broken signals.
* Allow user to clear solution if Solution or Baseline Tab plots are paused.

![Screen Shot 2022-02-17 at 6 14 50 PM](https://user-images.githubusercontent.com/43353147/154604731-4bfe35f4-4e5b-442f-bb9f-c40bc73e6c28.png)

