### PR TITLE
Ensure "show advanced settings" always split over two lines [CPP-692]

### DIFF
--- a/resources/SettingsTab.qml
+++ b/resources/SettingsTab.qml
@@ -287,7 +287,7 @@ MainTab {
                         Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                         padding: parent.buttonPadding
                         bottomPadding: refreshButton.bottomPadding
-                        text: "SHOW ADVANCED SETTINGS"
+                        text: "SHOW ADVANCED\nSETTINGS"
                         font.pointSize: refreshButton.font.pointSize
                         font.family: Constants.fontFamily
                         font.bold: false


### PR DESCRIPTION
![Peek 2022-03-25 11-12](https://user-images.githubusercontent.com/3880246/160029959-0d2aab77-d5db-48d8-976c-ccd36a7aed79.gif)

I started messing around with the SmallCheckBox.qml code to try to get the checkbox to be centered in the column as well but quickly got in over my head. If we think it'd be worth it I can keep trying to make it centered (while I guess making sure it's _not_ centered in the other places its used?), but this otherwise fixes the ask in the original ticket.