### PR TITLE
Bump up Windows max mem for bench.

### DIFF
--- a/utils/bench_runner.py
+++ b/utils/bench_runner.py
@@ -165,7 +165,7 @@ FRONTEND_MEM_BENCHMARKS: Dict[str, List[Dict[str, Any]]] = {
         {
             NAME: "piksi-relay-5sec",
             FILE_PATH: "data/piksi-relay-5sec.sbp",
-            MAXIMUM_MEAN_MB: 350,
+            MAXIMUM_MEAN_MB: 400,
             MAXIMUM_RATE_OF_MAX_MEAN: 0.05,
             MAXIMUM_RATE_OF_MAX_STD: 0.4,
         },


### PR DESCRIPTION
This PR added a noticeable chunk of memory to the app by adding a set of points for all solution modes. So bumping this up because it is occasionally failing in our CI.

https://github.com/swift-nav/swift-toolbox/pull/466 