### PR TITLE
MacOS fix long settings values cut off [CPP-694]

### DIFF
--- a/resources/SettingsTabComponents/SettingsPane.qml
+++ b/resources/SettingsTabComponents/SettingsPane.qml
@@ -118,7 +118,7 @@ Rectangle {
 
                         PropertyChanges {
                             target: valOnDevice
-                            Layout.preferredHeight: isLongTextField(_fieldName) ? 4 * parent.smallRowHeight : 3 * parent.smallRowHeight
+                            Layout.preferredHeight: isLongTextField(_fieldName) ? 5 * parent.smallRowHeight : 3 * parent.smallRowHeight
                         }
 
                     },
@@ -198,7 +198,7 @@ Rectangle {
                 Layout.rowSpan: 2
                 Layout.columnSpan: 1
                 Layout.preferredWidth: parent.colWidthLabel
-                Layout.preferredHeight: isLongTextField(_fieldName) ? 3 * parent.smallRowHeight : parent.smallRowHeight
+                Layout.preferredHeight: isLongTextField(_fieldName) ? 4 * parent.smallRowHeight : parent.smallRowHeight
                 sourceComponent: settingRowLabel
             }
 
@@ -209,7 +209,7 @@ Rectangle {
                 Layout.rowSpan: 2
                 Layout.columnSpan: parent.columns - 1
                 Layout.preferredWidth: parent.colWidthField
-                Layout.preferredHeight: isLongTextField(_fieldName) ? 3 * parent.smallRowHeight : parent.smallRowHeight
+                Layout.preferredHeight: isLongTextField(_fieldName) ? 4 * parent.smallRowHeight : parent.smallRowHeight
             }
 
             Loader {


### PR DESCRIPTION
This happens on MacOS with the larger font size.  Might be worth checking that this hasn't caused a regression on windows.

![Screen Shot 2022-03-28 at 3 01 38 pm](https://user-images.githubusercontent.com/26106369/160324741-4843406f-f6d2-4f62-af9b-9295d9994380.png)
