### PR TITLE
Uprevs black to 22.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = ["PySide2 ~= 5.15.2", "pycapnp ~= 1.1.0"]
 
 [project.optional-dependencies]
 test = [
-  "black ~= 21.6b0",
+  "black ~= 22.3",
   "jedi ~= 0.18.0",
   "mypy ~= 0.910",
   "pylint ~= 2.9.3",


### PR DESCRIPTION
Addresses this bug which recommends uprevving to 22.3.0+
https://github.com/psf/black/issues/2964