### PR TITLE
Clear connection notification before connecting to device.[CPP-710]

### DIFF
--- a/console_backend/src/connection.rs
+++ b/console_backend/src/connection.rs
@@ -115,8 +115,8 @@ fn conn_manager_thd(
         while let Ok(msg) = recv.wait() {
             match msg {
                 ConnectionManagerMsg::Connect(conn) => {
-                    send_conn_notification(&client_sender, String::from(""));
                     shared_state.set_connection(ConnectionState::Connecting, &client_sender);
+                    send_conn_notification(&client_sender, String::from(""));
                     let (reader, writer) = match conn.try_connect(Some(&shared_state)) {
                         Ok(rw) => rw,
                         Err(e) => {


### PR DESCRIPTION
On main branch the failure is observed in this order:
* Connect to device that would cause an error for example: `10.1.54.1abc`
* Disconnect from device and connect to valid ip: `10.1.54.1`
* Now disconnect and you will see the previous error message popup.

This clears the error notification whenever the user attempts to connect to a device.