### PR TITLE
Mac highres enabled for dmg #498

### DIFF
--- a/installers/macOS/Info.plist
+++ b/installers/macOS/Info.plist
@@ -4,5 +4,7 @@
 <dict>
 	<key>CFBundleIconFile</key>
 	<string>Swift Console.icns</string>
+	<key>NSHighResolutionCapable</key>
+	<string>True</string>
 </dict>
 </plist>


### PR DESCRIPTION
Looks much better to me. Strange that this works by default when using `cargo make run` but not in the dmg. Either way glad we will get this in before release.

<img width="1056" alt="Screen Shot 2022-04-01 at 5 30 27 PM" src="https://user-images.githubusercontent.com/43353147/161356921-d804c182-1ee2-4254-83b1-83d8d5d3aa5b.png">
<img width="1056" alt="Screen Shot 2022-04-01 at 5 31 09 PM" src="https://user-images.githubusercontent.com/43353147/161356917-ed5a57d4-59b9-4214-b6e1-ffa5c39a2fef.png">
