### PR TITLE
Rename v3.1.4 Windows shortcut if user wants to keep installation.

### DIFF
--- a/installers/Windows/Installer.nsi
+++ b/installers/Windows/Installer.nsi
@@ -23,7 +23,7 @@ Unicode true
 !define installer_dir "py39-dist"
 !define company_name "Swift Navigation"
 !define old_uninstaller "$PROGRAMFILES\${company_name}\${app_name}\Uninstall.exe"
-!define old_shortcut "OLD-${app_name}.lnk"
+!define old_shortcut "${app_name} (Old).lnk"
 
 !define vc_redist_url "https://aka.ms/vs/17/release/vc_redist.x64.exe"
 


### PR DESCRIPTION
This handles a corner case where the user chooses not to uninstall the old console <= v3.1.4 during the installation process.

* Moves the old console shortcut to "OLD-Swift Console" in the event the user chooses not to uninstall it.
* If the file has already been moved from a previous installation, it will continue with the installation even on failure.

The one drawback to this approach is that if the user ever intends to remove the old version of the console, it does not know about the moved shortcut, it will not be removed, and remain a stale shortcut on the users desktop. The old uninstaller does not return an error code so we would need to do something more clever to check if the user decided to delete the old app. 

