### PR TITLE
Refresh settings upon receipt of MsgStartup.[CPP-713]

### DIFF
--- a/console_backend/src/lib.rs
+++ b/console_backend/src/lib.rs
@@ -74,6 +74,7 @@ struct Tabs {
     pub status_bar: Mutex<StatusBar>,
     pub update: Mutex<UpdateTab>,
     pub settings: Option<SettingsTab>,
+    pub shared_state: shared_state::SharedState,
 }
 
 impl Tabs {
@@ -117,8 +118,9 @@ impl Tabs {
             )
             .into(),
             status_bar: StatusBar::new(shared_state.clone()).into(),
-            update: UpdateTab::new(shared_state).into(),
+            update: UpdateTab::new(shared_state.clone()).into(),
             settings: None,
+            shared_state,
         }
     }
 

--- a/console_backend/src/process_messages.rs
+++ b/console_backend/src/process_messages.rs
@@ -13,6 +13,7 @@ use sbp::{
         piksi::{MsgCommandResp, MsgDeviceMonitor, MsgNetworkStateResp, MsgThreadState},
         system::{
             MsgCsacTelemetry, MsgCsacTelemetryLabels, MsgHeartbeat, MsgInsStatus, MsgInsUpdates,
+            MsgStartup,
         },
         tracking::{MsgMeasurementState, MsgTrackingState},
     },
@@ -231,6 +232,9 @@ fn register_events(link: sbp::link::Link<Tabs>) {
     });
     link.register(|tabs: &Tabs, msg: MsgSvAzEl| {
         tabs.tracking_sky_plot.lock().unwrap().handle_sv_az_el(msg);
+    });
+    link.register(|tabs: &Tabs, _msg: MsgStartup| {
+        tabs.shared_state.set_settings_refresh(true);
     });
     link.register(|tabs: &Tabs, msg: MsgThreadState| {
         tabs.advanced_system_monitor


### PR DESCRIPTION
In the past if you rebooted the device, pretty reliably it would not load all the settings for newer piksi firmware. This will trigger a refresh upon receipt of the MsgStartup message which is indicative of the RTOS on the device being ready.

https://user-images.githubusercontent.com/43353147/162089219-e61b46dc-3c87-4151-a564-42f3074dcad9.mov

