### PR TITLE
Fix LogPanel logs not always appear[CPP-712]

### DIFF
--- a/resources/LogPanel.qml
+++ b/resources/LogPanel.qml
@@ -267,6 +267,14 @@ Item {
         repeat: true
         onTriggered: {
             log_panel_model.fill_data(logPanelData);
+            if (!tableView.model.rows.length) {
+                tableView.model.clear();
+                tableView.model.rows = [{
+                    [Constants.logPanel.timestampHeader]: "",
+                    [Constants.logPanel.levelHeader]: "",
+                    [Constants.logPanel.msgHeader]: ""
+                }];
+            }
             if (!logPanelData.entries.length)
                 return ;
 


### PR DESCRIPTION
It seems the previous PR having the "Console started..." message sent before a connection is not reliable still. The columnwidths do not inherit parent.width correctly when they become visible so tableView.model.clear seems to force this. Whenever there is no element in the tableView or if the user clears the tableView, this will trigger, add a blank row with correct columnwidths. Works well as far as I can tell.