### PR TITLE
Move Reboot Logic to Settings.[CPP-708]

### DIFF
--- a/console_backend/src/lib.rs
+++ b/console_backend/src/lib.rs
@@ -93,12 +93,7 @@ impl Tabs {
                 msg_sender.clone(),
             )
             .into(),
-            advanced_system_monitor: AdvancedSystemMonitorTab::new(
-                shared_state.clone(),
-                client_sender.clone(),
-                msg_sender.clone(),
-            )
-            .into(),
+            advanced_system_monitor: AdvancedSystemMonitorTab::new(client_sender.clone()).into(),
             baseline: BaselineTab::new(shared_state.clone(), client_sender.clone(), msg_sender)
                 .into(),
             tracking_signals: TrackingSignalsTab::new(shared_state.clone(), client_sender.clone())

--- a/console_backend/src/server_recv_thread.rs
+++ b/console_backend/src/server_recv_thread.rs
@@ -276,7 +276,7 @@ pub fn server_recv_thread(
                     shared_state.set_write_setting(Some(req));
                 }
                 m::message::AdvancedSystemMonitorStatusFront(Ok(_)) => {
-                    shared_state.set_reset_device(true);
+                    shared_state.set_device_reboot(true);
                 }
                 m::message::AdvancedNetworkingStatusFront(Ok(cv_in)) => {
                     let refresh = cv_in.get_refresh();

--- a/console_backend/src/settings_tab.rs
+++ b/console_backend/src/settings_tab.rs
@@ -80,6 +80,11 @@ fn tick(settings_tab: &SettingsTab, settings_state: SettingsTabState) {
             error!("Issue resetting settings {}", e);
         };
     }
+    if settings_state.reboot {
+        if let Err(e) = settings_tab.reset(false) {
+            error!("Issue rebooting device {}", e);
+        };
+    }
     if settings_state.save {
         if let Err(e) = settings_tab.save() {
             error!("Issue saving settings, {}", e);

--- a/console_backend/src/shared_state.rs
+++ b/console_backend/src/shared_state.rs
@@ -264,6 +264,11 @@ impl SharedState {
         let data = guard.settings_tab.get();
         guard.settings_tab.send(SettingsTabState { reset, ..data });
     }
+    pub fn set_device_reboot(&self, reboot: bool) {
+        let guard = self.lock();
+        let data = guard.settings_tab.get();
+        guard.settings_tab.send(SettingsTabState { reboot, ..data });
+    }
     pub fn set_settings_auto_survey_request(&self, auto_survey_request: bool) {
         let guard = self.lock();
         let data = guard.settings_tab.get();
@@ -308,9 +313,6 @@ impl SharedState {
         self.lock()
             .heartbeat_data
             .set_dgnss_enabled(dgnss_solution_mode != "No DGNSS");
-    }
-    pub fn set_reset_device(&self, reset_device: bool) {
-        self.lock().reset_device = reset_device;
     }
     pub fn set_advanced_networking_update(&self, update: AdvancedNetworkingState) {
         self.lock().advanced_networking_update = Some(update);
@@ -368,7 +370,6 @@ pub struct SharedStateInner {
     pub(crate) settings_tab: Watched<SettingsTabState>,
     pub(crate) console_version: String,
     pub(crate) firmware_version: Option<String>,
-    pub(crate) reset_device: bool,
     pub(crate) advanced_networking_update: Option<AdvancedNetworkingState>,
     pub(crate) auto_survey_data: AutoSurveyData,
     pub(crate) heartbeat_data: Heartbeat,
@@ -395,7 +396,6 @@ impl SharedStateInner {
             settings_tab: Watched::new(SettingsTabState::new()),
             console_version,
             firmware_version: None,
-            reset_device: false,
             advanced_networking_update: None,
             auto_survey_data: AutoSurveyData::new(),
             heartbeat_data,
@@ -606,6 +606,7 @@ impl AutoSurveyData {
 
 #[derive(Debug, Default, Clone)]
 pub struct SettingsTabState {
+    pub reboot: bool,
     pub refresh: bool,
     pub reset: bool,
     pub save: bool,


### PR DESCRIPTION
If you flash a device's firmware using a USB drive, when it resets, only a single message type gets through. 
Currently, the logic in the System Monitor Tab relies on another non-guaranteed message to be received to perform a reboot. This moves it to the Settings tab and reliably ticks.