### PR TITLE
entrypoint: validate QT_QPA_PLATFORM is empty

### DIFF
--- a/entrypoint/src/main.rs
+++ b/entrypoint/src/main.rs
@@ -25,7 +25,7 @@ fn handle_wayland() {
         if std::env::var(XDG_SESSION_TYPE).as_deref() == Ok(WAYLAND) {
             // Only override QT_QPA_PLATFORM if it's not already set
             if std::env::var(QT_QPA_PLATFORM).is_err() {
-              std::env::set_var(QT_QPA_PLATFORM, WAYLAND);
+                std::env::set_var(QT_QPA_PLATFORM, WAYLAND);
             }
         }
     }


### PR DESCRIPTION
Check that `QT_QPA_PLATFORM` is empty before we override it, this allows a user to set the variable to something other than `wayland` if they want to.