### PR TITLE
Rename MacOS App with Beta tag[CPP-749]

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -634,7 +634,7 @@ background_path = get_env BACKGROUND_PATH
 version_path = get_env VERSION_PATH
 version = readfile ${version_path}
 version = trim_end ${version}
-dmg_path = set ./${final_dir}/${app_original_name}_${version}_macos.dmg
+dmg_path = set ./${final_dir}/${app_original_name}_${version}-beta_macos.dmg
 
 old_dmgs = glob_array "./${final_dir}/*.dmg"
 for path in ${old_dmgs}

--- a/resources/view.qml
+++ b/resources/view.qml
@@ -8,6 +8,10 @@ import SwiftConsole 1.0
 ApplicationWindow {
     id: main
 
+    function titleBetaTag() {
+        return Qt.platform.os === "osx" ? " [Beta]" : ""; // Add beta tag for mac.
+    }
+
     Material.accent: Constants.swiftOrange
     width: Globals.width
     minimumWidth: Globals.minimumWidth
@@ -15,7 +19,7 @@ ApplicationWindow {
     minimumHeight: Globals.minimumHeight
     font.pixelSize: Constants.mediumPixelSize
     visible: true
-    title: (loggingBar.sbpRecording ? "[L] " : "     ") + statusBar.title
+    title: (loggingBar.sbpRecording ? "[L] " : "     ") + statusBar.title + titleBetaTag()
     color: Constants.swiftWhite
 
     ConnectionData {


### PR DESCRIPTION
* Adds a `<title> [Beta]` tag to the title of the application when run on mac.
* Adds a `-beta` semver addition to the version string embedded in the mac dmg.

Test Release:
https://github.com/swift-nav/swift-toolbox/releases/tag/v4.0.6-mac-beta (I realize using "mac-beta" as the version was not ideal for verifying the second feature)

Verified the tag only shows in the title bar on mac and does not show up on windows/linux.
<img width="1047" alt="Screen Shot 2022-05-09 at 2 36 16 PM" src="https://user-images.githubusercontent.com/43353147/167503288-885da932-7eea-430a-b861-2fae80d9bf04.png">
