### PR TITLE
Pin pycapnp to 1.1.0 to prevent build breakage [CPP-763]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ readme = "README.md"
 classifiers = []
 requires-python = ">=3.8"
 dynamic = ['version', 'description']
-dependencies = ["PySide2 ~= 5.15.2", "pycapnp ~= 1.1.0"]
+dependencies = ["PySide2 ~= 5.15.2", "pycapnp == 1.1.0"]
 
 [project.optional-dependencies]
 test = [


### PR DESCRIPTION
Looks like a new release of pycapnp, 1.1.1, has caused a bork in our application. By pinning to 1.1.0, the app works again.

I filed a ticket for investigating and fixing the issue: https://swift-nav.atlassian.net/browse/CPP-763
<img width="1049" alt="Screen Shot 2022-05-24 at 3 43 54 PM" src="https://user-images.githubusercontent.com/43353147/170144031-05737957-7423-4e05-a209-1fb66cd3c8c7.png">
