### PR TITLE
installer size regression: remove unecessary Python packages [CPP-768]

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -444,12 +444,6 @@ jobs:
             "$f"
           done
 
-          codesign \
-            -s "${{ secrets.APPLE_DEVELOPER_ID }}" \
-            --timestamp \
-            --options=runtime \
-            Contents/Resources/lib/python3.9/site-packages/shiboken2_generator/shiboken2
-
           for f in $(ls Contents/Resources/lib/python3.9/site-packages/**/Qt/lib/*.framework/Versions/5/*)
           do
             codesign \

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -304,7 +304,6 @@ env = { USE_PYTHON = { value = "${PYTHON}", condition = { env_not_set = [
 script_runner = "@duckscript"
 script = '''
 exec --fail-on-error ${USE_PYTHON} -m pip install pyside-wheels/shiboken2-5.15.2.1-5.15.2-cp39-cp39-${OS_WHEEL_LABEL}.whl
-exec --fail-on-error ${USE_PYTHON} -m pip install pyside-wheels/shiboken2_generator-5.15.2.1-5.15.2-cp39-cp39-${OS_WHEEL_LABEL}.whl
 exec --fail-on-error ${USE_PYTHON} -m pip install pyside-wheels/PySide2-5.15.2.1-5.15.2-cp39-cp39-${OS_WHEEL_LABEL}.whl
 '''
 

--- a/pyside-wheels/shiboken2_generator-5.15.2.1-5.15.2-cp39-cp39-linux_x86_64.whl
+++ b/pyside-wheels/shiboken2_generator-5.15.2.1-5.15.2-cp39-cp39-linux_x86_64.whl
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:30d6471939c68dc3b93f7dd2496f654de5db15381ba98dc3fc6dc6b69cb79b71
-size 40364872

--- a/pyside-wheels/shiboken2_generator-5.15.2.1-5.15.2-cp39-cp39-macosx_10_13_x86_64.whl
+++ b/pyside-wheels/shiboken2_generator-5.15.2.1-5.15.2-cp39-cp39-macosx_10_13_x86_64.whl
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:41fa8d453559c24b70834002b19712988436c9f461c00214b3211593df805528
-size 17220706

--- a/pyside-wheels/shiboken2_generator-5.15.2.1-5.15.2-cp39-cp39-win_amd64.whl
+++ b/pyside-wheels/shiboken2_generator-5.15.2.1-5.15.2-cp39-cp39-win_amd64.whl
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b2ef889f995591ff0b7766f3ea92d1a0a0804d7de9439c2bbc9b37c5e11da828
-size 21874706


### PR DESCRIPTION
Removes unnecessary shiboken generator wheels. Significantly reducing the size of the installers.
![Screen Shot 2022-05-26 at 12 53 23 PM](https://user-images.githubusercontent.com/43353147/170566840-d1108971-7a6e-410f-afb3-731111d9cc02.png)

