### PR TITLE
Fix InsSettingsPopup QML warnings columnWidths not defined

### DIFF
--- a/resources/SettingsTabComponents/InsSettingsPopup.qml
+++ b/resources/SettingsTabComponents/InsSettingsPopup.qml
@@ -53,7 +53,7 @@ Item {
         contentItem: Column {
             id: layout
 
-	    property variant columnWidths: [layout.width / 3, layout.width / 3, layout.width / 3]
+            property variant columnWidths: [layout.width / 3, layout.width / 3, layout.width / 3]
 
             width: parent.width
             spacing: Constants.insSettingsPopup.columnSpacing


### PR DESCRIPTION
On startup, numerous QML warnings about `columnWidths` not being defined
are issued for `InsSettingsPopup.qml` like follows:

```
qrc:/SettingsTabComponents/InsSettingsPopup.qml:0: ReferenceError: columnWidths is not defined
```

This fixes that issue.