### PR TITLE
linux: support Ubuntu 22.04 (remove libssl dependency) [CPP-766]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -737,6 +737,7 @@ dependencies = [
  "libz-sys",
  "openssl-sys",
  "pkg-config",
+ "rustls-ffi",
  "vcpkg",
  "winapi",
 ]
@@ -919,7 +920,7 @@ dependencies = [
  "futures-sink",
  "nanorand",
  "pin-project",
- "spin",
+ "spin 0.9.3",
 ]
 
 [[package]]
@@ -2176,6 +2177,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin 0.5.2",
+ "untrusted",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "rust-ini"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2213,6 +2229,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver 1.0.4",
+]
+
+[[package]]
+name = "rustls"
+version = "0.20.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aab8ee6c7097ed6057f43c187a62418d0c05a4bd5f18b3571db50ee0f9ce033"
+dependencies = [
+ "log",
+ "ring",
+ "sct",
+ "webpki",
+]
+
+[[package]]
+name = "rustls-ffi"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9da52707cca59e6eef8a78f3ad8d04024254a168ed1b41eb4dfa9616eace781a"
+dependencies = [
+ "libc",
+ "log",
+ "num_enum",
+ "rustls",
+ "rustls-pemfile",
+ "sct",
+ "webpki",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eebeaeb360c87bfb72e84abdb3447159c0eaececf1bef2aecd65a8be949d1c9"
+dependencies = [
+ "base64",
 ]
 
 [[package]]
@@ -2296,6 +2348,16 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "sct"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "sdl2"
@@ -2510,6 +2572,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spin"
@@ -2847,6 +2915,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "514672a55d7380da379785a4d70ca8386c8883ff7eaae877be4d2081cebe73d8"
 
 [[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
 name = "value-bag"
 version = "1.0.0-alpha.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3050,6 +3124,16 @@ checksum = "38eb105f1c59d9eaa6b5cdc92b859d85b926e82cb2e0945cd0c9259faa6fe9fb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -746,7 +746,6 @@ fpm \
   --force \
   --input-type dir \
   --output-type deb \
-  --depends "libssl1.1 | libssl3" \
   ${DEPENDS_SWITCHES[*]} \
   --maintainer "$MAINTAINER" \
   --description "$DESCRIPTION" \

--- a/console_backend/Cargo.toml
+++ b/console_backend/Cargo.toml
@@ -44,7 +44,7 @@ sbp = { version = "4.3.0", features = ["json", "link", "swiftnav"] }
 sbp-settings = "0.6.9"
 env_logger = { version = "0.9", optional = true }
 mimalloc = { version = "0.1", default-features = false }
-curl = { version = "0.4", features = ["ssl", "static-curl"] }
+curl = { version = "0.4", features = ["rustls", "static-curl"] }
 indicatif = { version = "0.16", optional = true }
 
 [target.'cfg(any(target_os = "macos", target_os = "windows"))'.dependencies]


### PR DESCRIPTION
Jira: https://swift-nav.atlassian.net/browse/CPP-766

Changes
- Uses the `rustls` library for crypto instead of openssl, this doesn't allow system updates of crypto libs, but allows us to support a wider range of Ubuntu builds
- The rust curl library dependency brings in OpenSSL 1.1 because we're building on Ubuntu 18.04 -- this does not work on Ubuntu 22.04 which does not have version 1.1 (it only has version 3.0)

Custom build here: https://github.com/swift-nav/swift-toolbox/releases/tag/v4.0.7-ubuntu2204

---

Ubuntu 22.04

![swift console ubuntu 22 04](https://user-images.githubusercontent.com/183436/171515984-5c809d59-4b72-4888-9839-7a14c3f568c4.png)

---

Ubuntu 20.04

![swift console ubuntu 20 04](https://user-images.githubusercontent.com/183436/171516017-70b85ab5-3c5f-4a44-92d5-943fc05c12b4.png)

---

Ubuntu 18.04

![swift console ubuntu 18 04](https://user-images.githubusercontent.com/183436/171516051-327f2446-afd5-407e-a951-bbda288aef6d.png)

---

Debian 11

![swift console - debian 11](https://user-images.githubusercontent.com/183436/171516100-fc27bd1e-ae68-4adb-aea5-fe137995a7f7.png)

---

Debian 10

![swift console - debian 10](https://user-images.githubusercontent.com/183436/171524635-e558815b-26b7-49d8-b7eb-6224960be5e0.png)