### PR TITLE
installer size regression: remove windows debug libraries [CPP-768]

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -520,9 +520,21 @@ if eq ${os} windows
             rm ${file}
         end
     end
+
     qtbins = glob_array ./Lib/site-packages/PySide2/*.exe
     for bin in ${qtbins}
         rm ${bin}
+    end
+
+    all_dlls = glob_array ./**/*.dll
+    for dll in ${all_dlls}
+        if ends_with ${dll} "d.dll"
+            dll_no_debug = substring ${dll} -5 # remove d.dll
+            dll_no_debug = concat ${dll_no_debug} ".dll"
+            if is_path_exists ${dll_no_debug}
+                rm ${dll}
+            end
+        end
     end
 else
     rm -r ./share


### PR DESCRIPTION
Jira: https://swift-nav.atlassian.net/browse/CPP-768

Test build of the installers here: https://github.com/swift-nav/swift-toolbox/releases/tag/v4.0.7-installer-size

Should help to fix a regression in the size of the installers for Windos.  This removes debug DLLs that get populated in the PySide2 wheel (which end up in our installer).

---

After change:
```
❯ fd -I --glob '*d.dll'
Lib\site-packages\PySide2\Qt5Gamepad.dll
Lib\site-packages\PySide2\plugins\gamepads\xinputgamepad.dll
Lib\site-packages\PySide2\plugins\platforms\qdirect2d.dll
Lib\site-packages\PySide2\plugins\renderplugins\scene2d.dll
Lib\site-packages\PySide2\plugins\scenegraph\qsgd3d12backend.dll
```

Before change:
```
❯ fd -I --glob '*d.dll'
Lib\site-packages\PySide2\Qt5Chartsd.dll
Lib\site-packages\PySide2\Qt5Concurrentd.dll
Lib\site-packages\PySide2\Qt5Cored.dll
Lib\site-packages\PySide2\Qt5DBusd.dll
Lib\site-packages\PySide2\Qt5Gamepad.dll
Lib\site-packages\PySide2\Qt5Gamepadd.dll
Lib\site-packages\PySide2\Qt5Guid.dll
Lib\site-packages\PySide2\Qt5Helpd.dll
Lib\site-packages\PySide2\Qt5MultimediaQuickd.dll
Lib\site-packages\PySide2\Qt5MultimediaWidgetsd.dll
Lib\site-packages\PySide2\Qt5Multimediad.dll
Lib\site-packages\PySide2\Qt5Networkd.dll
Lib\site-packages\PySide2\Qt5OpenGLd.dll
Lib\site-packages\PySide2\Qt5PositioningQuickd.dll
Lib\site-packages\PySide2\Qt5Positioningd.dll
Lib\site-packages\PySide2\Qt5PrintSupportd.dll
Lib\site-packages\PySide2\Qt5QmlModelsd.dll
...
```