### PR TITLE
fix: ssl regression on macOS (use `rustls` only on Linux) [CPP-766]

### DIFF
--- a/console_backend/Cargo.toml
+++ b/console_backend/Cargo.toml
@@ -44,11 +44,14 @@ sbp = { version = "4.3.0", features = ["json", "link", "swiftnav"] }
 sbp-settings = "0.6.9"
 env_logger = { version = "0.9", optional = true }
 mimalloc = { version = "0.1", default-features = false }
-curl = { version = "0.4", features = ["rustls", "static-curl"] }
 indicatif = { version = "0.16", optional = true }
 
 [target.'cfg(any(target_os = "macos", target_os = "windows"))'.dependencies]
 serialport = { git = "https://github.com/swift-nav/serialport-rs.git" }
+curl = { version = "0.4", features = ["ssl", "static-curl"] }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+curl = { version = "0.4", features = ["rustls", "static-curl"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = ">=0.24", features = [


### PR DESCRIPTION
Only use rustls on Linux [CPP-766]

[CPP-766]: https://swift-nav.atlassian.net/browse/CPP-766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

---

Should resolve this error seen on macOS

![image](https://user-images.githubusercontent.com/183436/171815813-bd040136-c522-4800-bf34-bf42435ec00a.png)