### PR TITLE
remove writable flag from app bundle

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -692,7 +692,7 @@ exec --fail-on-error mv ./${contents_resources_dir}/swift-console-splash "./${co
 exec --fail-on-error ln -s "../Resources/lib" ${contents_mac_os}/lib
 exec --fail-on-error ln -s "../Resources/.frozen" ${contents_mac_os}/.frozen
 exec --fail-on-error ln -s "../Resources/resources" ${contents_mac_os}/resources
-exec --fail-on-error chmod -R -w ${contents_mac_os}
+exec --fail-on-error find ${contents_mac_os} -type f -exec chmod -w {} \; 
 cp ./${info_plist_path} ./${contents_dir}/Info.plist
 mkdir ${contents_resources_dir}
 cp ${icns_path} ./${contents_resources_dir}/${app_file_prefix}.icns


### PR DESCRIPTION
Trying to assuage this code signing error on Catalina:

```
CODE SIGNING: 69506[Swift Console] vm_map_enter: curprot cannot be write+execute. failing
```