### PR TITLE
macos: make spctl happy (catalina support) [CPP-770]

### DIFF
--- a/installers/macOS/Info.plist
+++ b/installers/macOS/Info.plist
@@ -7,6 +7,6 @@
 	<key>NSHighResolutionCapable</key>
 	<string>True</string>
 	<key>CFBundlePackageType</key>
-        <string>APPL</string>
+	<string>APPL</string>
 </dict>
 </plist>


### PR DESCRIPTION
Doesn't allow the app to open yet but appears to resolve at least one problem, solution from https://stackoverflow.com/questions/39667482/problems-verifying-signature-of-osx-app-for-gatekeeper-sierra-the-code-is-va

---

Before this change:
```
consolebench@macbuild3 /Applications % spctl -vvvv --assess Swift\ Console.app
Swift Console.app: rejected (the code is valid but does not seem to be an app)
origin=Developer ID Application: Swift Navigation, Inc. (...)
```

---

After this change:
```
consolebench@macbuild3 /Applications % spctl -vvvv --assess Swift\ Console.app
Swift Console.app: accepted
source=Notarized Developer ID
```