### PR TITLE
Add QSG_RHI env var to fix windows flickering.[CPP-622]

### DIFF
--- a/entrypoint/src/main.rs
+++ b/entrypoint/src/main.rs
@@ -70,6 +70,7 @@ fn main() -> Result<()> {
     std::env::set_var("SWIFTNAV_CONSOLE_FROZEN", app_dir()?);
     std::env::set_var("PYTHONHOME", pythonhome_dir()?);
     std::env::set_var("PYTHONDONTWRITEBYTECODE", "1");
+    std::env::set_var("QSG_RHI", "1");
     handle_splash();
     let exit_code = Python::with_gil(|py| {
         let args = PyTuple::new(py, args);


### PR DESCRIPTION
Add environment variable to fix flickering on Windows.