### PR TITLE
Add QSG_RHI for Windows to fix flickering[CPP-622] (#638)

### DIFF
--- a/entrypoint/src/main.rs
+++ b/entrypoint/src/main.rs
@@ -70,6 +70,15 @@ fn main() -> Result<()> {
     std::env::set_var("SWIFTNAV_CONSOLE_FROZEN", app_dir()?);
     std::env::set_var("PYTHONHOME", pythonhome_dir()?);
     std::env::set_var("PYTHONDONTWRITEBYTECODE", "1");
+
+    // This enables the Qt Rendering Hardware Interface (RHI), to reduce observed render
+    // glitching on Windows. You can disable this feature by setting QSG_RHI=0 in your
+    // environment variables.
+    #[cfg(target_os = "windows")]
+    if std::env::var("QSG_RHI").is_err() {
+        std::env::set_var("QSG_RHI", "1");
+    }
+
     handle_splash();
     let exit_code = Python::with_gil(|py| {
         let args = PyTuple::new(py, args);


### PR DESCRIPTION
* Add QSG_RHI for Windows to fix flickering[CPP-622]

[CPP-622]: https://swift-nav.atlassian.net/browse/CPP-622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ