### PR TITLE
Support for PGM EVK settings[CPP-788]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2311,9 +2311,9 @@ dependencies = [
 
 [[package]]
 name = "sbp-settings"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1c0ad05e2d5b407dece4120911daaec83295df23faf46288ae96a00e8c1a53"
+checksum = "ffb7f171f1e41fd8ab94042eae61c628b63a433432094f7411dabe20ef075141"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-utils",

--- a/console_backend/Cargo.toml
+++ b/console_backend/Cargo.toml
@@ -41,7 +41,7 @@ parking_lot = "0.12.1"
 regex = { version = "1.6.0" }
 rust-ini = "0.18.0"
 sbp = { version = "4.5.0", features = ["json", "link", "swiftnav"] }
-sbp-settings = "0.6.11"
+sbp-settings = "0.6.12"
 env_logger = { version = "0.9", optional = true }
 mimalloc = { version = "0.1", default-features = false }
 indicatif = { version = "0.16", optional = true }

--- a/console_backend/src/update_tab.rs
+++ b/console_backend/src/update_tab.rs
@@ -190,9 +190,15 @@ fn wait_for_device_settings(
     update_tab_context: UpdateTabContext,
     shared_state: SharedState,
 ) -> Result<()> {
+    update_tab_context.fw_log_append(
+        "Warning: Settings received from Piksi do not contain firmware version information. \
+        Unable to determine software update status."
+            .to_string(),
+    );
     while is_running.get() && !update_tab_context.debug() {
         if let Some(firmware_version) = shared_state.firmware_version() {
             update_tab_context.set_current_firmware_version(firmware_version);
+            update_tab_context.fw_log_clear();
             check_console_outdated(update_tab_context.clone())?;
             check_firmware_outdated(update_tab_context.clone())?;
             check_above_v2(update_tab_context)?;

--- a/resources/UpdateTab.qml
+++ b/resources/UpdateTab.qml
@@ -247,7 +247,7 @@ MainTab {
                 fwLogTextArea.text = updateTabData.fw_text;
 
             firmwareDownload.downloadButtonEnable = !updateTabData.downloading && !updateTabData.upgrading;
-            firmwareVersion.upgradeButtonEnable = !updateTabData.upgrading && !updateTabData.downloading;
+            firmwareVersion.upgradeButtonEnable = updateTabData.fw_version_current && !updateTabData.upgrading && !updateTabData.downloading;
             if (!firmwareVersion.localFileTextEditing)
                 firmwareVersion.localFileText = updateTabData.fw_local_filename;
 


### PR DESCRIPTION
* Uprev libsettings-rs to 0.6.12 which now handles packets from a device which do not contain a fmt_type field.
* Instead of arbitrarily loading the firmware version from settings, now check that the product_id contains a substring of either "Piksi Multi" or "Duro".
* Adds a blurb to the Update tab log panel if no current firmware version has been set, situations for this would be pgm_evk, reading a file, or connected to the readonly piksi relay.
* Disable the Upgrade button if no current firmware version is available.