### PR TITLE
Remove unused selectedRow logic

### DIFF
--- a/resources/Constants/Globals.qml
+++ b/resources/Constants/Globals.qml
@@ -17,16 +17,9 @@ QtObject {
     property int minimumWidth: 900
     property string conn_state: Constants.connection.disconnected.toUpperCase()
     property string copyClipboard: ""
-    property var tablesWithHighlights: []
     property var currentSelectedTable: null
     property bool showFileConnection: false
     property QtObject updateTabData
-
-    function clearHighlightedRows() {
-        for (var i in tablesWithHighlights) {
-            tablesWithHighlights[i].selectedRow = -1;
-        }
-    }
 
     updateTabData: QtObject {
         property bool consoleOutdated: false

--- a/resources/LogPanel.qml
+++ b/resources/LogPanel.qml
@@ -280,8 +280,6 @@ Item {
                 rows.unshift(new_row);
                 tableView.model.rows = rows.slice(0, Constants.logPanel.maxRows);
             }
-            if (logPanelData.entries.length && tableView.selectedRow != -1)
-                tableView.selectedRow += logPanelData.entries.length;
             logPanelData.entries = [];
         }
     }

--- a/resources/TableComponents/SwiftTableView.qml
+++ b/resources/TableComponents/SwiftTableView.qml
@@ -10,7 +10,6 @@ TableView {
     property alias verticalScrollBar: _verticalScrollBar
     property variant columnWidths: []
     property variant columnAlignments: []
-    property int selectedRow: -1
     property int _currentSelectedIndex: -1
     property bool stayFocused: false
     property int currentSelectedIndex: (!stayFocused && Globals.currentSelectedTable == this) ? _currentSelectedIndex : -1


### PR DESCRIPTION
These are remnants of a prior selection method that are no longer used. Unnecessary updating of this selectedRow variable is made when no one is accessing it.