### PR TITLE
Reduce the update frequency of the log panel to 5hz

### DIFF
--- a/resources/LogPanel.qml
+++ b/resources/LogPanel.qml
@@ -249,7 +249,7 @@ Item {
     }
 
     Timer {
-        interval: Globals.currentRefreshRate
+        interval: Utils.hzToMilliseconds(Globals.currentRefreshRate)
         running: parent.visible
         repeat: true
         onTriggered: {


### PR DESCRIPTION
The update frequency of the log panel was erroneously set to every 5ms (200hz). This was causing a lot of unnecessary processing that was discovered during QML profiling.

This should help the app run significantly better on lower end hardware.