### PR TITLE
Update public_suffix before fpm install.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -266,6 +266,7 @@ jobs:
                 build-essential \
                 libudev-dev \
                 libssl-dev
+              sudo gem install public_suffix -v 4.0.7  # This is a fix for U18.
               sudo gem install --no-document fpm
           elif [ "$RUNNER_OS" == "macOS" ]; then
               brew install capnp llvm create-dmg


### PR DESCRIPTION
On U18, it appears the minimum version for ruby public_suffix is not sufficient to install fpm. The error suggests running this to uprev public_suffix before installing fpm.

Wasn't sure if we should only push this into the swift-toolbox-4.0.0-branch and start a divergence or not. Seems like it will work fine with U20+ though 🤷 

This should be the last fix needed for v4.0.13 release.
https://github.com/swift-nav/swift-toolbox/pull/750