### PR TITLE
enable opengl functionality [CPP-805]

### DIFF
--- a/swiftnav_console/main.py
+++ b/swiftnav_console/main.py
@@ -606,7 +606,7 @@ def handle_cli_arguments(args: argparse.Namespace, globals_: QObject):
     if args.show_fileio:
         globals_.setProperty("showFileio", True)  # type: ignore
     if args.use_opengl:
-        os.environ['QSG_RHI_BACKEND'] = "opengl"
+        os.environ["QSG_RHI_BACKEND"] = "opengl"
         globals_.setProperty("useOpenGL", True)  # type: ignore
     if args.no_antialiasing:
         globals_.setProperty("useAntiAliasing", False)  # type: ignore


### PR DESCRIPTION
after long and hard testing...
it seems...

RHI backend defaults to directx and metal for win, mac respectively, we need to assign it as opengl manually or it wont work.

this simply enables opengl functionality, tested working for mac,

```
cargo make run --use-opengl
```

does not resolve these issues in the log...

```
QOpenGLFramebufferObject: Framebuffer incomplete attachment.
QOpenGLFramebufferObject: Framebuffer incomplete, missing attachment.
```