### PR TITLE
Force refresh filtered tracking signals [CPP-828] [CPP-826]

### DIFF
--- a/console_backend/src/server_recv_thread.rs
+++ b/console_backend/src/server_recv_thread.rs
@@ -92,11 +92,7 @@ pub fn server_recv_thread(
                         .iter()
                         .map(|x| String::from(x.unwrap()))
                         .collect();
-                    shared_state
-                        .lock()
-                        .tracking_tab
-                        .signals_tab
-                        .check_visibility = check_visibility;
+                    shared_state.set_check_visibility(check_visibility);
                 }
                 m::message::LoggingBarFront(Ok(cv_in)) => {
                     let directory = cv_in

--- a/console_backend/src/tabs/tracking_tab/tracking_signals_tab.rs
+++ b/console_backend/src/tabs/tracking_tab/tracking_signals_tab.rs
@@ -385,7 +385,7 @@ impl TrackingSignalsTab {
     }
 
     /// Package data into a message buffer and send to frontend.
-    fn send_data(&mut self) {
+    pub fn send_data(&mut self) {
         let mut builder = Builder::new_default();
         let msg = builder.init_root::<crate::console_backend_capnp::message::Builder>();
 


### PR DESCRIPTION
add a event receiver thread to handle refreshing (this would be useful for i.e. sending capnproto refresh / QOL trigger instant refreshes or anything we want from frontend -> backend -> frontend roundtrip)