### PR TITLE
Log format selection bug and null check [CPP-834]

### DIFF
--- a/resources/LoggingBar.qml
+++ b/resources/LoggingBar.qml
@@ -266,6 +266,8 @@ Rectangle {
             repeat: true
             onTriggered: {
                 logging_bar_model.fill_data(loggingBarData);
+                sbpLoggingButton.checked = loggingBarData.sbp_logging;
+                csvLoggingButton.checked = loggingBarData.csv_logging;
                 if (loggingBarData.recording_filename)
                     recordingFilenameText.editText = loggingBarData.recording_filename;
                 if (mockTime) {


### PR DESCRIPTION
Previous behaviour:
https://user-images.githubusercontent.com/35755741/202049432-42225cc1-aa37-4f8a-b923-4e01be428c5e.mov

Current behaviour:
https://user-images.githubusercontent.com/35755741/202049454-df864427-c653-4b29-b4e5-56498afafba1.mov

Unsure if it is better to do the null check for text, it seems kinda cool having it lag a bit like its 'loading'