### PR TITLE
Add documentation on setting up qmlformat.

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -903,7 +903,7 @@ makensis /V4  .\installers\Windows\Installer.nsi
 dependencies = ["set-qml-files", "set-qml-app"]
 script_runner = "@shell"
 script = '''
-qmlformat -i ${QML_FILES}
+qmlformat --verbose -i ${QML_FILES}
 '''
 
 # TODO Fix tool location when available in PySide6 wheels[CPP-799]
@@ -912,7 +912,7 @@ dependencies = ["set-qml-files", "set-qml-app"]
 script_runner = "powershell"
 script_extension = "ps1"
 script = '''
-& qmlformat -i $(-split ${env:QML_FILES})
+& qmlformat --verbose  -i $(-split ${env:QML_FILES})
 '''
 
 [tasks.qml-lint]

--- a/README.md
+++ b/README.md
@@ -141,6 +141,33 @@ cargo make create-dist
 cargo make frontend-cpu-bench
 ```
 
+## QML Formatting
+The `qmlformat` tool is not included in the Qt PySide6 pip packages so the quickest (only?) way to get the tool is by installing Qt on your machine. In CI, we rely on a quick installer tool `aqt` to achieve this.
+
+* Create a python 3.7+ virtual environment:
+  ```
+  conda create -n qt python=3.10
+  ```
+* Install the `aqt` package:
+  ```
+  pip install aqtinstall
+  ```
+* Install the desired version of qt. This website will help you customize the install command for your machine, https://ddalcino.github.io/aqt-list-server/ . Here are some OS specific generic install commands (visit the website if you need a different architecture):
+  ```
+  # Linux
+  aqt install-qt linux desktop 6.3.1 gcc_64
+  # MacOS
+  aqt install-qt mac desktop 6.3.1 clang_64
+  # Windows
+  aqt install-qt windows desktop 6.3.1 win64_msvc2019_64
+  ```
+* Add the `qmlformat` tool to your path. It is located in `<qt install dir>/<qt version>/<arch>/bin/`, this may be different depending on your system.
+
+* Now you can run the tool, but use this cargo make command to match CI behavior:
+  ```
+  cargo make qml-format
+  ```
+
 ## QML Profiling
 
 Download the universal Qt installer from qt.io. Run the installer, pick custom


### PR DESCRIPTION
Adds some documentation on how to set up qmlformat quickly until the binary is included with PySide6 wheels similar to qml-lint.