### PR TITLE
adjust rate limit for retry CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -198,3 +198,4 @@ jobs:
           propagate_failure: true
           wait_workflow: true
           trigger_workflow: true
+          wait_interval: 120


### PR DESCRIPTION
bumping frontend CI to query every 2 mins instead should help with the rate limiting - can always click into it to see if it failed or not but since many things uses this token 

(believe its affected by publisher / swift-cli ci + multiple instances of frontend waits, all those CIs)

might have to adjust even more if that ^^ is happening
