### PR TITLE
remove loglevel enum [CPP-884]

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,11 @@ Either connect to a device via the GUI or command line and include the flag:
 ```
 This will save a `.pickle` file in your current working directory.
 
-**NOTE:** This recording is not intended to be compatible with other console versions.
+**NOTE:** Use of this recording is intended only for debugging the swift-console and not for
+long term storage of streams. There is no guarantee the recording will be compatible with
+other console versions, as the messaging format between backend and frontend has no guarantee
+of backwards or forwards compatibility
+
 Debugging internal messaging should be version specific and recording it should be tied
 to its version.
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ Either connect to a device via the GUI or command line and include the flag:
 ```
 This will save a `.pickle` file in your current working directory.
 
+**NOTE:** This recording is not intended to be compatible with other console versions.
+Debugging internal messaging should be version specific and recording it should be tied
+to its version.
+
 ### (Debug) Replaying a stream from the backend in frontend (with or without Rust).
 If you have recorded a capnp recording pickle file as shown in the previous step, now you
 can replay this file. If you already have the standard development environment set up, you
@@ -420,6 +424,10 @@ just to cross language barriers). Other formats like protobufs require a parsing
 phase -- capnproto also has very ergonomic Python bindings. Other formats such as
 [flatbuffers][] achieve similar goals as *capnproto* but do not have good
 Python support.
+
+**We do not intend on allowing backward compatibility** in internal message passing via
+capnproto. There may be releases that modify internal message structures and should 
+not be relied on even though these internal packets are being exposed.
 
 [capnproto]: https://capnproto.org/
 [flatbuffers]: https://google.github.io/flatbuffers/

--- a/console_backend/tests/data/console-capnp-20220419-033358.pickle
+++ b/console_backend/tests/data/console-capnp-20220419-033358.pickle
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6b38bb7bb6df9a9a890ea659298693e8211b4e391171674badb00d05e033e117
-size 2507040

--- a/src/main/resources/base/console_backend.capnp
+++ b/src/main/resources/base/console_backend.capnp
@@ -27,14 +27,6 @@ struct LogLevelFront {
     logLevel @0 :Text;
 }
 
-enum LogLevel {
-    err @0;
-    warning @1;
-    info @2;
-    debug @3;
-    trace @4;
-}
-
 struct LogEntry {
     timestamp @0 :Text;
     level @1 :Text;

--- a/utils/loop_generate_core.sh
+++ b/utils/loop_generate_core.sh
@@ -6,6 +6,8 @@
 # No interactive debugger is invoked for this script - just crash and
 # generate core file for later inspection.
 
+# run with PATH_TO_PICKLE set to specify capnp recording
+
 if [ "$core_pat" != "core" ]; then
     echo "/proc/sys/kernel/core_pattern incorrect: '$core_pat', should be 'core'"
     echo "Please run the following as root:"
@@ -22,7 +24,7 @@ I=0
 while [ true ]
 do
     echo "++++++++++++++++++++++" $I
-python -m swiftnav_console.main --read-capnp-recording console_backend/tests/data/console-capnp-20220419-033358.pickle
+python -m swiftnav_console.main --read-capnp-recording $PATH_TO_PICKLE
 if [ $? -ne 0 ]; then
     break
 fi


### PR DESCRIPTION
just a small hack related to LogLevel#error being generated to conflict `Self::Error`, 
since we hotfixed this in the #917 by using text instead of enums (think that takes more bytes), this enum is no longer needed.
