### PR TITLE
skip invalid elevation angle [CPP-895]

### DIFF
--- a/console_backend/src/tabs/tracking_tab/tracking_sky_plot_tab.rs
+++ b/console_backend/src/tabs/tracking_tab/tracking_sky_plot_tab.rs
@@ -81,6 +81,9 @@ impl TrackingSkyPlotTab {
                     label = format!("{label}*");
                 }
                 let code = azel.sid.code as i32;
+                if azel.el < -90 || azel.el > 90 {
+                    return;
+                }
                 let obs = SkyPlotObs {
                     az: azel.az as u16 * 2,
                     el: 90 - azel.el as u16,


### PR DESCRIPTION
for the file attached in ticket gives elevation angle of -91 which causes
```
thread '<unnamed>' panicked at 'attempt to subtract with overflow', console_backend/src/tabs/tracking_tab/tracking_sky_plot_tab.rs:87:25
```

since sbp docs say elevation is supposed to be (-90, 90), will just skip on these invalid values.