### PR TITLE
downgrade pyside from 6.4.1 to 6.3.2 [CPP-905]

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -168,7 +168,7 @@ jobs:
       - name: Install Qt
         uses: jurplel/install-qt-action@910f37ee23653fd4b243fe5c7f81ff26a8a6a64e
         with:
-          version: '6.4.1'
+          version: '6.3.2'
           setup-python: false
 
       - name: Run Checks

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -90,7 +90,7 @@ PY_BASE_URL = "https://github.com/indygreg/python-build-standalone/releases/down
 SWFT_PY_BASE_URL = "https://github.com/swift-nav/python-build-standalone/releases/download/20220205%2Bswift"
 MACOSX_DEPLOYMENT_TARGET = "10.15"
 APP_NAME = "swift-console"
-QT_VERSION = "6.4.1"                                                                                         # Also needs to be updated in .github/workflows/main.yml
+QT_VERSION = "6.3.2"                                                                                         # Also needs to be updated in .github/workflows/main.yml
 
 [tasks.init]
 


### PR DESCRIPTION
settings table scrolling is laggy on 6.4.1, downgrading back to 6.3.2 works fine.

should have no compatibility issues reverting.