### PR TITLE
add --disable-map cli option [CPP-911]

### DIFF
--- a/console_backend/src/cli_options.rs
+++ b/console_backend/src/cli_options.rs
@@ -101,6 +101,10 @@ pub struct CliOptions {
     #[clap(long)]
     pub show_file_connection: bool,
 
+    /// Disable map.
+    #[clap(long)]
+    pub disable_map: bool,
+
     /// Path to a yaml file containing known piksi settings.
     #[clap(long)]
     pub settings_yaml: Option<PathBuf>,

--- a/resources/Constants/Globals.qml
+++ b/resources/Constants/Globals.qml
@@ -33,6 +33,7 @@ QtObject {
     property int initialSubTabIndex: 0 // Signals
     property bool showCsvLog: false
     property bool showFileio: false
+    property bool disableMap: false
     property int height: 600
     property int minimumHeight: 600
     property int width: 1000

--- a/resources/SolutionTab.qml
+++ b/resources/SolutionTab.qml
@@ -30,7 +30,7 @@ import "SolutionTabComponents" as SolutionTabComponents
 MainTab {
     id: solutionTab
 
-    subTabNames: ["Position", "Velocity", "Map"]
+    subTabNames: Globals.disableMap ? ["Position", "Velocity"] : ["Position", "Velocity", "Map"]
     curSubTabIndex: 0
 
     SplitView {

--- a/swiftnav_console/main.py
+++ b/swiftnav_console/main.py
@@ -650,6 +650,8 @@ def handle_cli_arguments(args: argparse.Namespace, globals_: QObject):
             globals_.setProperty("width", args.width)  # type: ignore
     if args.show_file_connection:
         globals_.setProperty("showFileConnection", True)  # type: ignore
+    if args.disable_map:
+        globals_.setProperty("disableMap", True)  # type: ignore
     try:
         if args.ssh_tunnel:
             ssh_tunnel.setup(args.ssh_tunnel, args.ssh_remote_bind_address)
@@ -708,6 +710,7 @@ def main(passed_args: Optional[Tuple[str, ...]] = None) -> int:
     parser.add_argument("--record-capnp-recording", action="store_true")
     parser.add_argument("--debug-with-no-backend", action="store_true")
     parser.add_argument("--show-fileio", action="store_true")
+    parser.add_argument("--disable-map", action="store_true")
     parser.add_argument("--show-file-connection", action="store_true")
     parser.add_argument("--no-prompts", action="store_true")
     parser.add_argument("--use-opengl", action="store_true")


### PR DESCRIPTION
apparently tab loads are lazy.
so we can basically just remove the tab from layout.
tested with javascript logging 'loaded' msg that only pops up whenever you click into the map.

also means all the concerns about performance previously can be disregarded. is actually pretty good not as bad as imagined.