### PR TITLE
fix sticky settings value bug [CPP-923]

### DIFF
--- a/resources/SettingsTabComponents/SettingsPane.qml
+++ b/resources/SettingsTabComponents/SettingsPane.qml
@@ -365,9 +365,8 @@ Rectangle {
             anchors.centerIn: parent
             anchors.verticalCenterOffset: 5
             onEditingFinished: {
-                if (settingType === "float" || settingType === "double")
-                    text = text.replace(",", ".");
-                backend_request_broker.settings_write_request(settingGroup, settingName, text);
+                let isNumericField = settingType === "float" || settingType === "double";
+                backend_request_broker.settings_write_request(settingGroup, settingName, isNumericField ? text.replace(",", ".") : text);
             }
             validator: {
                 if (settingType === "integer")


### PR DESCRIPTION
some how `text` gets persisted even when changing panes
this should fix the sticky value bug. which changing values on double/float causes it to fix the value even when looking at other setting entries