### PR TITLE
ci: update imagemagick install cmd for windows

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -446,7 +446,7 @@ script_runner = "@duckscript"
 script = '''
 wget -O imagemagick.tool.7.1.0.nupkg https://github.com/swift-nav/swift-toolchains/releases/download/imagemagick-7.1.0/imagemagick.tool.7.1.0.nupkg
 exec --fail-on-error choco install -q -y --side-by-side vcredist2010 --version=10.0.40219.32503
-exec --fail-on-error choco install -q -y ./imagemagick.tool.7.1.0.nupkg
+exec --fail-on-error choco install -q -y imagemagick.tool --version="7.1.0" --source="."
 rm imagemagick.tool.7.1.0.nupkg
 '''
 


### PR DESCRIPTION
Recent versions of choco appear to have introduced a behavior change
which is producing the following error in CI:

	Package name cannot be a path to a file on a remote, or local file system.

	To install a local, or remote file, you may use:
	  choco install imagemagick.tool --version="7.1.0" --source="D:\a\swift-toolbox\swift-toolbox"

	[cargo-make] ERROR - Error while running duckscript: Source: Unknown Line: 5 - Error while executing command, exit code: 1
	[cargo-make] WARN - Build Failed.
	Error: Process completed with exit code 1.

This updates CI to account for this behavior change.
