### PR TITLE
Support PGM in tracking signals tab[DIP-64]

### DIFF
--- a/console_backend/src/process_messages.rs
+++ b/console_backend/src/process_messages.rs
@@ -31,7 +31,7 @@ use sbp::{
         observation::{MsgObsDepA, MsgSvAzEl},
         orientation::{MsgAngularRate, MsgBaselineHeading, MsgOrientEuler},
         piksi::{MsgDeviceMonitor, MsgNetworkStateResp, MsgThreadState},
-        system::{MsgHeartbeat, MsgInsStatus, MsgInsUpdates, MsgStartup},
+        system::{MsgHeartbeat, MsgInsStatus, MsgInsUpdates, MsgStartup, MsgStatusReport},
         tracking::{MsgMeasurementState, MsgTrackingState},
     },
 };
@@ -320,6 +320,12 @@ fn register_events(link: sbp::link::Link<Tabs>) {
             .lock()
             .unwrap()
             .handle_specan(msg);
+    });
+    link.register(|tabs: &Tabs, msg: MsgStatusReport| {
+        tabs.tracking_signals
+            .lock()
+            .unwrap()
+            .handle_msg_status_report(msg);
     });
     link.register(|tabs: &Tabs, msg: MsgSvAzEl| {
         tabs.tracking_sky_plot.lock().unwrap().handle_sv_az_el(msg);


### PR DESCRIPTION
# Implements
* Adds handle_msg_status_report to the TrackingSignalsTab to discern whether the source device is a PGM.
* If the device is a PGM, we disable the processing of MsgTrackingState and MsgMeasurementState in favor of MsgObs.

# Concerns
* There is a slight visual artifact at the beginning of the stream which is due to the delayed reception of the MsgStatusReport but after the message is received things look normal.

[Screencast from 07-21-2023 07:10:02 PM.webm](https://github.com/swift-nav/swift-toolbox/assets/43353147/1afff5f3-e7b5-4940-a22e-491d62b54b4d)

