### PR TITLE
Handle bad log messages, add log-level,log-stdout cli args

### DIFF
--- a/console_backend/src/cli_options.rs
+++ b/console_backend/src/cli_options.rs
@@ -85,6 +85,14 @@ pub struct CliOptions {
     #[clap(long)]
     pub log_console: bool,
 
+    /// Log to stdout.
+    #[clap(long)]
+    pub log_stdout: bool,
+
+    /// Set log level.
+    #[clap(long, value_parser = log_level)]
+    pub log_level: Option<LogLevel>,
+
     /// Log CSV data to default / specified log file.
     #[clap(long)]
     pub csv_log: bool,
@@ -307,9 +315,15 @@ pub fn handle_cli(opt: CliOptions, conn_manager: &ConnectionManager, shared_stat
         shared_state.set_logging_directory(PathBuf::from(folder));
     }
     shared_state.lock().logging_bar.csv_logging = CsvLogging::from(opt.csv_log);
+    if let Some(log_level) = opt.log_level {
+        shared_state.set_log_level(log_level);
+    }
     if opt.log_console {
         let filename = chrono::Local::now().format(LOG_FILENAME).to_string().into();
         shared_state.set_log_filename(Some(filename));
+    }
+    if opt.log_stdout {
+        shared_state.set_log_stdout(true);
     }
     if let Some(path) = opt.sbp_log_filename {
         shared_state.set_sbp_logging_filename(Some(path));

--- a/console_backend/src/shared_state.rs
+++ b/console_backend/src/shared_state.rs
@@ -120,6 +120,12 @@ impl SharedState {
     pub fn set_log_filename(&self, filename: Option<PathBuf>) {
         self.lock().log_panel.filename = filename;
     }
+    pub fn log_stdout(&self) -> bool {
+        self.lock().log_panel.stdout
+    }
+    pub fn set_log_stdout(&self, stdout: bool) {
+        self.lock().log_panel.stdout = stdout;
+    }
     pub fn reset_logging(&self) {
         let mut guard = self.lock();
         guard.logging_bar.sbp_logging = false;
@@ -515,6 +521,7 @@ impl LoggingBarState {
 pub struct LogPanelState {
     pub level: LogLevel,
     pub filename: Option<PathBuf>,
+    pub stdout: bool,
 }
 
 impl LogPanelState {
@@ -522,6 +529,7 @@ impl LogPanelState {
         LogPanelState {
             level: LogLevel::WARNING,
             filename: None,
+            stdout: false,
         }
     }
 }


### PR DESCRIPTION
## Implements
* Handle bad log messages. When the console starts with Debug logging enabled there were a few messages that have escaped quotation chars which would cause the console to crash so this regex should remove those.
* Add cli argument for setting the log level, on master the default log level was WARNING so no lower-level warnings would get dumped to a file/console until you start the console and then set the level. I think adding this as an argument is pretty reasonable, but if there is pushback, we can set it as hidden.
* Add cli argument for dumping logs to stdout. I find it is much easier to debug an issue if we can dump the logs to a terminal window instead of a separate log file every time the console starts. Again if there is pushback we can set the argument to hidden.
