### PR TITLE
Fix issue with InstallQt Github Action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -170,6 +170,7 @@ jobs:
         with:
           version: '6.4.3'
           setup-python: false
+          aqtversion: '==3.1.6'
 
       - name: Run Checks
         run: cargo make check-all


### PR DESCRIPTION
There was an issue downloading the sha for some of the Qt archives for github actions related to the aqt dependency. The suggested fix was here:
https://github.com/jurplel/install-qt-action/issues/187