### PR TITLE
fix taplo version@0.8.1 & resolve compilation errors with --locked

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -131,11 +131,9 @@ args = ["update", "stable"]
 
 [tasks.cargo-make-deps-update]
 dependencies = ["rustup-update"]
-install_crate = { crate_name = "cargo-update", binary = "cargo-install-update", test_arg = [
-  "-V",
-], min_version = "7.0.1" }
-command = "cargo"
-args = ["install-update", "taplo-cli", "cargo-make"]
+script = '''
+cargo install taplo-cli@0.8.1 --locked
+'''
 
 [tasks.generate-common-constants-rs]
 script_runner = "@duckscript"


### PR DESCRIPTION
This PR installs taplo-cli with the tip described [here](https://taplo.tamasfe.dev/cli/installation/cargo.html). Namely you should use `--locked` if you are getting compliation errors (and we were).

I also chose to lock taplo to v0.8.1. It would be trivial to switch this to take the latest.