### PR TITLE
Collection of fixes to get CI running.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
     name: Backend Benchmarks
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-11, windows-2019]
+        os: [ubuntu-20.04, macos-12, windows-2019]
     runs-on: ${{ matrix.os }}
     steps:
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ This will save a `.pickle` file in your current working directory.
 **NOTE:** Use of this recording is intended only for debugging the swift-console and not for
 long term storage of streams. There is no guarantee the recording will be compatible with
 other console versions, as the messaging format between backend and frontend has no guarantee
-of backwards or forwards compatibility
+of backwards or forwards compatibility.
 
 Debugging internal messaging should be version specific and recording it should be tied
 to its version.

--- a/console_backend/src/fft_monitor.rs
+++ b/console_backend/src/fft_monitor.rs
@@ -152,7 +152,7 @@ impl FftMonitor {
         if let Some(chan) = channel {
             channels.append(&mut vec![chan]);
         } else {
-            channels = self.channels.clone();
+            channels.clone_from(&self.channels);
         }
         for chan in channels {
             if let Some(chan_en) = self.enabled.get_mut(&chan) {

--- a/console_backend/src/tabs/advanced_tab/advanced_spectrum_analyzer_tab.rs
+++ b/console_backend/src/tabs/advanced_tab/advanced_spectrum_analyzer_tab.rs
@@ -79,10 +79,10 @@ impl AdvancedSpectrumAnalyzerTab {
                     if let Some(most_recent_fft) = ffts.pop() {
                         self.fft_monitor.clear_ffts(None);
                         if let Some(amplitudes) = most_recent_fft.get(&String::from(AMPLITUDES)) {
-                            self.most_recent_amplitudes = amplitudes.clone();
+                            self.most_recent_amplitudes.clone_from(amplitudes);
                         }
                         if let Some(frequencies) = most_recent_fft.get(&String::from(FREQUENCIES)) {
-                            self.most_recent_frequencies = frequencies.clone();
+                            self.most_recent_frequencies.clone_from(frequencies);
                         }
 
                         self.send_data();

--- a/console_backend/src/tabs/advanced_tab/advanced_system_monitor_tab.rs
+++ b/console_backend/src/tabs/advanced_tab/advanced_system_monitor_tab.rs
@@ -216,14 +216,14 @@ mod tests {
             uart_ftdi: uart_ftdi.clone(),
             latency,
         }));
-        assert_eq!(*tab.obs_latency.get(&CURR.to_string()).unwrap(), current);
-        assert_eq!(*tab.obs_latency.get(&AVG.to_string()).unwrap(), avg);
-        assert_eq!(*tab.obs_latency.get(&MIN.to_string()).unwrap(), lmin);
-        assert_eq!(*tab.obs_latency.get(&MAX.to_string()).unwrap(), lmax);
-        assert_eq!(*tab.obs_period.get(&CURR.to_string()).unwrap(), no_period);
-        assert_eq!(*tab.obs_period.get(&AVG.to_string()).unwrap(), no_period);
-        assert_eq!(*tab.obs_period.get(&MIN.to_string()).unwrap(), no_period);
-        assert_eq!(*tab.obs_period.get(&MAX.to_string()).unwrap(), no_period);
+        assert_eq!(*tab.obs_latency.get(CURR).unwrap(), current);
+        assert_eq!(*tab.obs_latency.get(AVG).unwrap(), avg);
+        assert_eq!(*tab.obs_latency.get(MIN).unwrap(), lmin);
+        assert_eq!(*tab.obs_latency.get(MAX).unwrap(), lmax);
+        assert_eq!(*tab.obs_period.get(CURR).unwrap(), no_period);
+        assert_eq!(*tab.obs_period.get(AVG).unwrap(), no_period);
+        assert_eq!(*tab.obs_period.get(MIN).unwrap(), no_period);
+        assert_eq!(*tab.obs_period.get(MAX).unwrap(), no_period);
         let avg = 1;
         let current = 2;
         let lmin = 3;
@@ -250,14 +250,14 @@ mod tests {
             latency,
             obs_period,
         }));
-        assert_eq!(*tab.obs_latency.get(&CURR.to_string()).unwrap(), current);
-        assert_eq!(*tab.obs_latency.get(&AVG.to_string()).unwrap(), avg);
-        assert_eq!(*tab.obs_latency.get(&MIN.to_string()).unwrap(), lmin);
-        assert_eq!(*tab.obs_latency.get(&MAX.to_string()).unwrap(), lmax);
-        assert_eq!(*tab.obs_period.get(&CURR.to_string()).unwrap(), current);
-        assert_eq!(*tab.obs_period.get(&AVG.to_string()).unwrap(), avg);
-        assert_eq!(*tab.obs_period.get(&MIN.to_string()).unwrap(), pmin);
-        assert_eq!(*tab.obs_period.get(&MAX.to_string()).unwrap(), pmax);
+        assert_eq!(*tab.obs_latency.get(CURR).unwrap(), current);
+        assert_eq!(*tab.obs_latency.get(AVG).unwrap(), avg);
+        assert_eq!(*tab.obs_latency.get(MIN).unwrap(), lmin);
+        assert_eq!(*tab.obs_latency.get(MAX).unwrap(), lmax);
+        assert_eq!(*tab.obs_period.get(CURR).unwrap(), current);
+        assert_eq!(*tab.obs_period.get(AVG).unwrap(), avg);
+        assert_eq!(*tab.obs_period.get(MIN).unwrap(), pmin);
+        assert_eq!(*tab.obs_period.get(MAX).unwrap(), pmax);
     }
 
     #[test]

--- a/console_backend/src/tabs/baseline_tab.rs
+++ b/console_backend/src/tabs/baseline_tab.rs
@@ -112,12 +112,16 @@ impl BaselineTab {
             nsec: Some(0),
             shared_state,
             sln_cur_data: {
-                let mut data = vec![Vec::with_capacity(1); NUM_GNSS_MODES];
+                let mut data = (0..NUM_GNSS_MODES)
+                    .map(|_| Vec::with_capacity(1))
+                    .collect::<Vec<_>>();
                 data.reserve_exact(NUM_GNSS_MODES);
                 data
             },
             sln_data: {
-                let mut data = vec![Vec::with_capacity(PLOT_HISTORY_MAX); NUM_GNSS_MODES];
+                let mut data = (0..NUM_GNSS_MODES)
+                    .map(|_| Vec::with_capacity(PLOT_HISTORY_MAX))
+                    .collect::<Vec<_>>();
                 data.reserve_exact(NUM_GNSS_MODES);
                 data
             },

--- a/console_backend/src/tabs/observation_tab.rs
+++ b/console_backend/src/tabs/observation_tab.rs
@@ -111,7 +111,7 @@ impl ObservationTable {
         self.gps_week = wn;
         self.prev_obs_total = obs_total;
         self.prev_obs_count = 0;
-        self.old_carrier_phase = self.new_carrier_phase.clone();
+        self.old_carrier_phase.clone_from(&self.new_carrier_phase);
         self.incoming_obs.clear();
         self.new_carrier_phase.clear();
         self.rows.clear();

--- a/console_backend/src/tabs/settings_tab.rs
+++ b/console_backend/src/tabs/settings_tab.rs
@@ -181,7 +181,7 @@ impl SettingsTab {
     }
 
     pub fn get(&self, group: &str, name: &str) -> Result<SettingsEntry> {
-        self.settings.lock().get(group, name).map(Clone::clone)
+        self.settings.lock().get(group, name).cloned()
     }
 
     pub fn group(&self, group: &str) -> Result<Vec<SettingsEntry>> {

--- a/console_backend/src/tabs/solution_tab/solution_position_tab.rs
+++ b/console_backend/src/tabs/solution_tab/solution_position_tab.rs
@@ -138,12 +138,16 @@ impl SolutionPositionTab {
             nsec: Some(0),
             shared_state,
             sln_cur_data: {
-                let mut data = vec![Vec::with_capacity(1); NUM_GNSS_MODES];
+                let mut data = (0..NUM_GNSS_MODES)
+                    .map(|_| Vec::with_capacity(1))
+                    .collect::<Vec<_>>();
                 data.reserve_exact(NUM_GNSS_MODES);
                 data
             },
             sln_data: {
-                let mut data = vec![Vec::with_capacity(PLOT_HISTORY_MAX); NUM_GNSS_MODES];
+                let mut data = (0..NUM_GNSS_MODES)
+                    .map(|_| Vec::with_capacity(PLOT_HISTORY_MAX))
+                    .collect::<Vec<_>>();
                 data.reserve_exact(NUM_GNSS_MODES);
                 data
             },

--- a/console_backend/src/tabs/update_tab.rs
+++ b/console_backend/src/tabs/update_tab.rs
@@ -446,11 +446,12 @@ fn send_file(update_tab_context: UpdateTabContext, fileio: &mut Fileio) -> anyho
         let size = file_blob.metadata()?.len() as usize;
         let mut bytes_written = 0;
         update_tab_context.fw_log_replace_last("Writing 0.0%...".to_string());
-        match fileio.overwrite_with_progress(destination, file_blob, |n| {
+        let on_progress = |n| {
             bytes_written += n;
             let progress = (bytes_written as f64) / (size as f64) * 100.0;
             update_tab_context.fw_log_replace_last(format!("Writing {progress:.2}%..."));
-        }) {
+        };
+        match fileio.overwrite_with_progress(destination, file_blob, on_progress) {
             Ok(_) => {
                 update_tab_context.fw_log_append(String::from("File transfer complete."));
             }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ include = ["swiftnav_console/console_resources.py"]
 
 [tool.black]
 line-length = 120
+exclude = "standalone-py/"
 
 [tool.pylint.MASTER]
 jobs = 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ include = ["swiftnav_console/console_resources.py"]
 
 [tool.black]
 line-length = 120
-exclude = "standalone-py/"
 
 [tool.pylint.MASTER]
 jobs = 0

--- a/utils/glob.ds
+++ b/utils/glob.ds
@@ -13,7 +13,7 @@ fn glob_paths_excluding_target
         filename = concat ${cargo_home} "/" ${i}
         unix_filename = replace ${filename} \\ /
         ignored = array_contains ${gi_unix} ${unix_filename}
-        if not contains ${ignored} \"false\"
+        if not contains ${ignored} "false"
             array_push ${out} ${unix_filename}
         end
     end


### PR DESCRIPTION
* Clippy fixes.
* Fixed an issue with new cargo make duckscript. We were character escaping a boolean which seems to be invalid now. Fixing this now allows the correct collection of python files to be globbed for python checks to run.
* Uprev macos-11 to macos-12 due to deprecation.