### PR TITLE
Fix map view feature

### DIFF
--- a/console_backend/src/cli_options.rs
+++ b/console_backend/src/cli_options.rs
@@ -109,10 +109,6 @@ pub struct CliOptions {
     #[clap(long)]
     pub show_file_connection: bool,
 
-    /// Enable map.
-    #[clap(long)]
-    pub enable_map: bool,
-
     /// Enable ntrip client
     #[clap(long)]
     pub enable_ntrip: bool,

--- a/console_backend/src/tabs/baseline_tab.rs
+++ b/console_backend/src/tabs/baseline_tab.rs
@@ -149,7 +149,7 @@ impl BaselineTab {
     /// # Parameters
     /// - `mode_string`: The mode string to attempt to prepare data for frontend.
     /// - `update_current`: Indicating whether the current solution should be updated by
-    /// this modes last n/e entry.
+    ///     this modes last n/e entry.
     fn _synchronize_plot_data_by_mode(&mut self, mode_string: &str, update_current: bool) {
         let mode_idx = match self.mode_strings.iter().position(|x| *x == *mode_string) {
             Some(idx) => idx,

--- a/console_backend/src/tabs/solution_tab/solution_position_tab.rs
+++ b/console_backend/src/tabs/solution_tab/solution_position_tab.rs
@@ -752,7 +752,7 @@ impl SolutionPositionTab {
     /// # Parameters
     /// - `mode_string`: The mode string to attempt to prepare data for frontend.
     /// - `update_current`: Indicating whether the current solution should be updated by
-    /// this modes last lat/lon entry.
+    ///     this modes last lat/lon entry.
     fn _synchronize_plot_data_by_mode(&mut self, mode_string: &str, update_current: bool) {
         let idx = match self.mode_strings.iter().position(|x| x == mode_string) {
             Some(idx) => idx,

--- a/resources/Constants/Globals.qml
+++ b/resources/Constants/Globals.qml
@@ -33,7 +33,6 @@ QtObject {
     property int initialSubTabIndex: 0 // Signals
     property bool showCsvLog: false
     property bool showFileio: false
-    property bool enableMap: false
     property int height: 600
     property int minimumHeight: 600
     property int width: 1000

--- a/resources/SolutionTab.qml
+++ b/resources/SolutionTab.qml
@@ -57,15 +57,7 @@ MainTab {
             SolutionTabComponents.SolutionVelocityTab {
             }
 
-            Rectangle {
-                width: parent.width
-                height: parent.height
-                Loader {
-                    sourceComponent: Globals.enableMap ? solutionMap : null
-                }
-            }
-
-            property Component solutionMap: SolutionTabComponents.SolutionMapTab {
+            SolutionTabComponents.SolutionMapTab {
             }
         }
     }

--- a/resources/SolutionTab.qml
+++ b/resources/SolutionTab.qml
@@ -58,6 +58,7 @@ MainTab {
             }
 
             SolutionTabComponents.SolutionMapTab {
+                visible: Globals.enableMap
             }
         }
     }

--- a/resources/SolutionTab.qml
+++ b/resources/SolutionTab.qml
@@ -30,7 +30,7 @@ import "SolutionTabComponents" as SolutionTabComponents
 MainTab {
     id: solutionTab
 
-    subTabNames: Globals.enableMap ? ["Position", "Velocity", "Map"] : ["Position", "Velocity"]
+    subTabNames: ["Position", "Velocity", "Map"]
     curSubTabIndex: 0
 
     SplitView {
@@ -58,7 +58,6 @@ MainTab {
             }
 
             SolutionTabComponents.SolutionMapTab {
-                visible: Globals.enableMap
             }
         }
     }

--- a/resources/web/map/js/trajectory_raw.js
+++ b/resources/web/map/js/trajectory_raw.js
@@ -130,7 +130,9 @@ function setupLayers() {
 }
 
 function syncCrumbCoords(){
-    map.getSource('breadcrumb').setData({
+    let breadcrumb = map.getSource('breadcrumb');
+    if (breadcrumb === undefined) return;
+    breadcrumb.setData({
         type: 'Feature',
         geometry: {
             type: 'LineString',
@@ -142,10 +144,12 @@ function syncCrumbCoords(){
 function syncLayers() {
     // sync route datas with stored points
     for (let i = 0; i < lines.length; i++) {
-        map.getSource(`route${i}`).setData(data[i]);
+        let route = map.getSource(`route${i}`);
+        if (route !== undefined) route.setData(data[i]);
     }
     // clear protection, since its only one point and temporary
-    map.getSource('prot').setData({
+    let prot = map.getSource('prot');
+    if (prot !== undefined) prot.setData({
         type: 'FeatureCollection',
         features: []
     });

--- a/resources/web/map/js/trajectory_raw.js
+++ b/resources/web/map/js/trajectory_raw.js
@@ -2,16 +2,21 @@ import mapboxGlStyleSwitcher from 'https://cdn.skypack.dev/mapbox-gl-style-switc
 
 const lines = ["#FF0000", "#FF00FF", "#00FFFF", "#0000FF", "#00FF00", "#000000"];
 const LNG_KM = 111.320, LAT_KM = 110.574;
+const mapContainer =  'map';
+const mapStyle = "mapbox://styles/mapbox/light-v11?optimize=true";
+const mapCenter = [-122.486052, 37.830348];  // Initial focus coordinate
+const mapZoom = 16;
+const mapPerformanceMetricsCollection = false;
 
 function decode(r){var n=r,t=[0,10,13,34,38,92],e=new Uint8Array(1.75*n.length|0),f=0,o=0,a=0;function i(r){o|=(r<<=1)>>>a,8<=(a+=7)&&(e[f++]=o,o=r<<7-(a-=8)&255)}for(var u=0;u<n.length;u++){var c,d=n.charCodeAt(u);127<d?(7!=(c=d>>>8&7)&&i(t[c]),i(127&d)):i(d)}r=new Uint8Array(e,0,f);var s=new TextDecoder().decode(r);while (s.slice(-1)=="\x00") s=s.slice(0,-1); return s;}
 
 mapboxgl.accessToken = decode("@ACCESS_TOKEN@");
 var map = new mapboxgl.Map({
-    container: 'map',
-    style: "mapbox://styles/mapbox/light-v11?optimize=true",
-    center: [-122.486052, 37.830348],  // Initial focus coordinate
-    zoom: 16,
-    performanceMetricsCollection: false,
+    container: mapContainer,
+    style: mapStyle,
+    center: mapCenter,
+    zoom: mapZoom,
+    performanceMetricsCollection: mapPerformanceMetricsCollection,
 });
 
 var focusCurrent = false;
@@ -242,4 +247,19 @@ map.on('style.load', () => {
 map.on('load', () => {
     console.log("loaded");
     setupLayers();
+});
+
+map.on('error', () => {
+    if (mapboxgl.accessToken != "@ACCESS_TOKEN@") {
+        console.log("Attempting to use local environment variable MAPBOX_TOKEN");
+        mapboxgl.accessToken = "@ACCESS_TOKEN@";
+        map.remove();
+        map = new mapboxgl.Map({
+            container: mapContainer,
+            style: mapStyle,
+            center: mapCenter,
+            zoom: mapZoom,
+            performanceMetricsCollection: mapPerformanceMetricsCollection,
+        });
+    }
 });

--- a/swiftnav_console/main.py
+++ b/swiftnav_console/main.py
@@ -667,8 +667,6 @@ def handle_cli_arguments(args: argparse.Namespace, globals_: QObject):
             globals_.setProperty("width", args.width)  # type: ignore
     if args.show_file_connection:
         globals_.setProperty("showFileConnection", True)  # type: ignore
-    if args.enable_map:
-        globals_.setProperty("enableMap", True)  # type: ignore
     if args.enable_ntrip:
         globals_.setProperty("enableNtrip", True)  # type: ignore
     try:
@@ -729,7 +727,6 @@ def main(passed_args: Optional[Tuple[str, ...]] = None) -> int:
     parser.add_argument("--record-capnp-recording", action="store_true")
     parser.add_argument("--debug-with-no-backend", action="store_true")
     parser.add_argument("--show-fileio", action="store_true")
-    parser.add_argument("--enable-map", action="store_true")
     parser.add_argument("--show-file-connection", action="store_true")
     parser.add_argument("--no-prompts", action="store_true")
     parser.add_argument("--use-opengl", action="store_true")

--- a/swiftnav_console/main.py
+++ b/swiftnav_console/main.py
@@ -44,10 +44,10 @@ from PySide6.QtWebEngineQuick import QtWebEngineQuick
 
 from PySide6.QtWidgets import QApplication, QSplashScreen  # type: ignore
 
-from PySide6.QtCore import QCoreApplication, QLoggingCategory, QObject, QUrl, QThread, QTimer, Slot, Signal, Qt, QLocale
+from PySide6.QtCore import QLoggingCategory, QObject, QUrl, QThread, QTimer, Slot, Signal, Qt, QLocale
 from PySide6 import QtCharts  # pylint: disable=unused-import
 
-from PySide6 import QtQml
+from PySide6 import QtQml, QtCore
 
 from PySide6.QtGui import QFontDatabase, QIcon, QPixmap
 
@@ -771,7 +771,7 @@ def main(passed_args: Optional[Tuple[str, ...]] = None) -> int:
                 found_help_arg = True
         args_main, _ = parser.parse_known_args(passed_args)
     if args_main.no_high_dpi:
-        QCoreApplication.setAttribute(Qt.AA_Use96Dpi)  # type: ignore
+        QtCore.QCoreApplication.setAttribute(Qt.AA_Use96Dpi)  # type: ignore
     if args_main.qmldebug:
         sys.argv.append("-qmljsdebugger=port:10002,block")
         debug = QQmlDebuggingEnabler()  # pylint: disable=unused-variable
@@ -780,8 +780,8 @@ def main(passed_args: Optional[Tuple[str, ...]] = None) -> int:
     # Silence webengine context logging.
     web_engine_context_log = QLoggingCategory("qt.webenginecontext")  # type: ignore
     web_engine_context_log.setFilterRules("*.info=false")
-    QCoreApplication.setAttribute(Qt.ApplicationAttribute.AA_ShareOpenGLContexts)
-    QCoreApplication.setAttribute(Qt.ApplicationAttribute.AA_UseDesktopOpenGL)
+    QtCore.QCoreApplication.setAttribute(QtCore.Qt.ApplicationAttribute.AA_ShareOpenGLContexts)
+    QtCore.QCoreApplication.setAttribute(QtCore.Qt.ApplicationAttribute.AA_UseDesktopOpenGL)
     QtWebEngineQuick.initialize()
     app = QApplication(sys.argv)
     app.setWindowIcon(QIcon(":/images/icon.ico"))

--- a/swiftnav_console/main.py
+++ b/swiftnav_console/main.py
@@ -778,7 +778,7 @@ def main(passed_args: Optional[Tuple[str, ...]] = None) -> int:
 
     QLocale.setDefault(QLocale.c())
     # Silence webengine context logging.
-    web_engine_context_log = QLoggingCategory("qt.webenginecontext")
+    web_engine_context_log = QLoggingCategory("qt.webenginecontext")  # type: ignore
     web_engine_context_log.setFilterRules("*.info=false")
     QCoreApplication.setAttribute(Qt.ApplicationAttribute.AA_ShareOpenGLContexts)
     QCoreApplication.setAttribute(Qt.ApplicationAttribute.AA_UseDesktopOpenGL)
@@ -793,7 +793,6 @@ def main(passed_args: Optional[Tuple[str, ...]] = None) -> int:
     QFontDatabase.addApplicationFont(":/fonts/RobotoCondensed-Regular.ttf")
     QQuickStyle.setStyle("Material")
     # We specifically *don't* want the RobotoCondensed-Bold.ttf font so we get the right look when bolded.
-
 
     qmlRegisterType(ConnectionData, "SwiftConsole", 1, 0, "ConnectionData")  # type: ignore
     qmlRegisterType(AdvancedImuPoints, "SwiftConsole", 1, 0, "AdvancedImuPoints")  # type: ignore


### PR DESCRIPTION
## Existing Bug
* Currently if the user attempts to use `--enable-map` on the master branch it crashes the application.
![image](https://github.com/user-attachments/assets/a8bd6fcf-8c8f-4d90-8217-49b48eaa9666)

## Implements
* Re-enables the map feature such that the tab is always visible.
* Removes the "enableMap" feature, as it is not working in the existing implementation.
* To allow developers the ability to see the map without the token being encoded, I add a retry mechanism where it will attempt to load whatever the user had locally stored in `MAPBOX_TOKEN` environment variable. 
* Mutes a few verbose logs relevant to the webengine loading.
* [mapbox allows up to 50k map loads for free](https://www.mapbox.com/pricing#map-loads-for-web) per month so it seems relatively harmless to always include the feature.

## Options
* I don't think the conditionally loading with the Globals.enableMap feature is the best solution, and would require a bit of QML finesse to get it working properly (mainly hiding the tab when not enabled). So one option which this PR enables is to keep it on all the time.
* Second option is removing it entirely.
* Third option would be to try and rework the QML to get conditional loading working which may have a bit of a learning curve. Lots of trial and error.

## Testing
* I built a test tag `v4.1.21-jm-test` and here is the map feature in action.

https://github.com/user-attachments/assets/2fb801e3-2a89-4b42-a718-ad91082a5650

