### PR TITLE
CPP-967: always show File connection input, remove dead --show-file-connection flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ installers/Windows/NSIS/*
 swiftnav_console/.idea
 /resources/base/
 /resources/web/map/js/trajectory.js
+.companion/

--- a/console_backend/src/cli_options.rs
+++ b/console_backend/src/cli_options.rs
@@ -105,10 +105,6 @@ pub struct CliOptions {
     #[clap(long)]
     pub show_fileio: bool,
 
-    /// Allow File Connections.
-    #[clap(long)]
-    pub show_file_connection: bool,
-
     /// Enable map.
     #[clap(long)]
     pub enable_map: bool,

--- a/resources/ConnectionScreen.qml
+++ b/resources/ConnectionScreen.qml
@@ -113,7 +113,7 @@ Item {
                     RadioButton {
                         id: serialRadio
 
-                        checked: (previous_connection_type == "Serial" || previous_connection_type == "File" && !Globals.showFileConnection)
+                        checked: previous_connection_type == "Serial"
                         text: serial_usb
                         onToggled: dialogRect.forceActiveFocus()
                     }
@@ -129,10 +129,9 @@ Item {
                     RadioButton {
                         id: fileRadio
 
-                        checked: previous_connection_type == "File" && Globals.showFileConnection
+                        checked: previous_connection_type == "File"
                         text: file
                         onToggled: dialogRect.forceActiveFocus()
-                        visible: Globals.showFileConnection
                     }
 
                     Item {

--- a/resources/Constants/Globals.qml
+++ b/resources/Constants/Globals.qml
@@ -41,7 +41,6 @@ QtObject {
     property string conn_state: Constants.connection.disconnected.toUpperCase()
     property string copyClipboard: ""
     property var currentSelectedTable: null
-    property bool showFileConnection: false
     property QtObject updateTabData
 
     updateTabData: QtObject {

--- a/swiftnav_console/main.py
+++ b/swiftnav_console/main.py
@@ -668,8 +668,6 @@ def handle_cli_arguments(args: argparse.Namespace, globals_: QObject):
             )
         else:
             globals_.setProperty("width", args.width)  # type: ignore
-    if args.show_file_connection:
-        globals_.setProperty("showFileConnection", True)  # type: ignore
     if args.enable_map:
         globals_.setProperty("enableMap", True)  # type: ignore
         MAP_ENABLED[0] = True
@@ -734,7 +732,6 @@ def main(passed_args: Optional[Tuple[str, ...]] = None) -> int:
     parser.add_argument("--debug-with-no-backend", action="store_true")
     parser.add_argument("--show-fileio", action="store_true")
     parser.add_argument("--enable-map", action="store_true")
-    parser.add_argument("--show-file-connection", action="store_true")
     parser.add_argument("--no-prompts", action="store_true")
     parser.add_argument("--use-opengl", action="store_true")
     parser.add_argument("--no-high-dpi", action="store_true")

--- a/swiftnav_console/main.py
+++ b/swiftnav_console/main.py
@@ -731,6 +731,7 @@ def main(passed_args: Optional[Tuple[str, ...]] = None) -> int:
     parser.add_argument("--record-capnp-recording", action="store_true")
     parser.add_argument("--debug-with-no-backend", action="store_true")
     parser.add_argument("--show-fileio", action="store_true")
+    parser.add_argument("--show-file-connection", action="store_true")
     parser.add_argument("--enable-map", action="store_true")
     parser.add_argument("--no-prompts", action="store_true")
     parser.add_argument("--use-opengl", action="store_true")
@@ -747,6 +748,10 @@ def main(passed_args: Optional[Tuple[str, ...]] = None) -> int:
         parser.add_argument("--ssh-remote-bind-address", type=str, default=None)
 
     args_main, unknown_args = parser.parse_known_args()
+    if args_main.show_file_connection:
+        parser.error(
+            "--show-file-connection argument is now permanently enabled and does not need to be passed anymore. Argument will be removed in future releases."
+        )
     for unknown_arg in unknown_args:
         for tunnel_arg in ("--ssh-tunnel", "--ssh-remote-bind-address"):
             if tunnel_arg in unknown_arg:

--- a/swiftnav_console/main.py
+++ b/swiftnav_console/main.py
@@ -750,7 +750,8 @@ def main(passed_args: Optional[Tuple[str, ...]] = None) -> int:
     args_main, unknown_args = parser.parse_known_args()
     if args_main.show_file_connection:
         parser.error(
-            "--show-file-connection argument is now permanently enabled and does not need to be passed anymore. Argument will be removed in future releases."
+            "--show-file-connection argument is now permanently enabled and does not need to be passed anymore. "
+            "Argument will be removed in future releases."
         )
     for unknown_arg in unknown_args:
         for tunnel_arg in ("--ssh-tunnel", "--ssh-remote-bind-address"):


### PR DESCRIPTION
## Summary
- Always show the **File** connection option in the console; drop the `--show-file-connection` gate
- The Browse (`...`) button and `*.sbp` picker already existed — they now appear with the File tab.
- Remove the now-dead `showFileConnection` global and the `--show-file-connection` flag (Python argparse + Rust clap).

## Test plan
- `cargo check -p console-backend` green; `qmllint` clean; Python `py_compile` OK.
- Regenerated the QML resource bundle (`makers generate-resources`).
- Manual (please confirm on your machine): launch without the flag → File radio visible → pick a `.sbp` via Browse → Connect.

## New behavior
<img width="1001" height="630" alt="Screenshot 2026-07-21 at 12 26 11 PM" src="https://github.com/user-attachments/assets/1cb28280-b266-4ef9-a05a-e2868fa9a05f" />


## Notes
- No behavior change to the file-connection backend path (`connect_file`).
- Building `console-backend` here needed `CMAKE_POLICY_VERSION_MINIMUM=3.5` (pre-existing cmake-4 env issue, unrelated to this change).
