### PR TITLE
Add Docker image for building and running swift-toolbox

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,21 +2,29 @@ FROM rust:1.88.0-slim
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
-                        cmake \
-                        libclang-dev \
                         capnproto \
-                        zstd \
-                        imagemagick \
+                        cmake \
                         fonts-freefont-otf \
-                        git \
-                        qt6-declarative-dev-tools \
-                        pkgconf \
-                        libssl-dev \
                         g++ \
-                        libnss3 \
+                        git \
+                        imagemagick \
                         libasound2 \
+                        libclang-dev \
+                        libgl1 \
+                        libnss3 \
+                        libssl-dev \
+                        libxcomposite1 \
+                        libxdamage1 \
+                        libxi6 \
                         libxkbfile1 \
+                        libxrandr2 \
+                        libxrender1 \
+                        libxtst6 \
+                        make \
+                        pkgconf \
+                        qt6-declarative-dev-tools \
                         xz-utils \
+                        zstd \
   && cargo install --force cargo-make taplo-cli \
   && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,4 +36,4 @@ ENV XDG_SESSION_TYPE=x11
 #
 # Developers may also wish to use `cargo make build-console` to perform
 # the compilation stages without creating the entire redistributable package.
-CMD cargo make setup-builder; cargo make create-dist
+CMD cargo make setup-builder && cargo make create-dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update \
 
 ENV PATH=/usr/local/cargo/bin:/usr/lib/qt6/bin:${PATH}
 
-RUN useradd -u 1000 -ms /bin/bash -G sudo builder
+RUN useradd -u 1000 -ms /bin/bash builder
 
 USER builder
 WORKDIR /work

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM rust:1.88.0-slim
 
 RUN apt-get update \
-  && apt-get install -y cmake \
+  && apt-get install -y --no-install-recommends \
+                        cmake \
                         libclang-dev \
                         capnproto \
                         zstd \
@@ -16,7 +17,8 @@ RUN apt-get update \
                         libasound2 \
                         libxkbfile1 \
                         xz-utils \
-  && cargo install --force cargo-make taplo-cli
+  && cargo install --force cargo-make taplo-cli \
+  && rm -rf /var/lib/apt/lists/*
 
 ENV PATH=/usr/local/cargo/bin:/usr/lib/qt6/bin:${PATH}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+FROM rust:1.88.0-slim
+
+RUN apt-get update \
+  && apt-get install -y cmake \
+                        libclang-dev \
+                        capnproto \
+                        zstd \
+                        imagemagick \
+                        fonts-freefont-otf \
+                        git \
+                        qt6-declarative-dev-tools \
+                        python-is-python3 \
+                        pkgconf \
+                        libssl-dev \
+                        g++ \
+                        libnss3 \
+                        libasound2 \
+                        libxkbfile1 \
+  && cargo install --force cargo-make taplo-cli
+
+ENV PATH=/usr/local/cargo/bin:/usr/lib/qt6/bin:${PATH}
+
+RUN useradd -u 1000 -ms /bin/bash -G sudo builder
+
+USER builder
+WORKDIR /work
+
+ENV HOME=/home/builder
+ENV CARGO_HOME=${HOME}/.cargo
+ENV XDG_SESSION_TYPE=xcb
+
+# change `build-console` to `run` to execute without fully compiling
+CMD cargo make setup-builder; cargo make build-console

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update \
                         libnss3 \
                         libasound2 \
                         libxkbfile1 \
+                        xz-utils \
   && cargo install --force cargo-make taplo-cli
 
 ENV PATH=/usr/local/cargo/bin:/usr/lib/qt6/bin:${PATH}
@@ -26,7 +27,13 @@ WORKDIR /work
 
 ENV HOME=/home/builder
 ENV CARGO_HOME=${HOME}/.cargo
-ENV XDG_SESSION_TYPE=xcb
+ENV XDG_SESSION_TYPE=x11
 
-# change `build-console` to `run` to execute without fully compiling
-CMD cargo make setup-builder; cargo make build-console
+# Change `cargo make create-dist` to `cargo make run` to build and execute the
+# console in-place (using a debug build).  Note that this requires Docker to be
+# configured to forward the display to the host, e.g.:
+# docker run -it --net=host -v $PWD:/work:rw -v /tmp/.X11-unix:/tmp/.X11-unix -v $HOME/.Xauthority:/home/builder/.Xauthority -e DISPLAY=$DISPLAY -h $HOSTNAME <image hash>
+#
+# Developers may also wish to use `cargo make build-console` to perform
+# the compilation stages without creating the entire redistributable package.
+CMD cargo make setup-builder; cargo make create-dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ RUN apt-get update \
                         fonts-freefont-otf \
                         git \
                         qt6-declarative-dev-tools \
-                        python-is-python3 \
                         pkgconf \
                         libssl-dev \
                         g++ \

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1335,7 +1335,7 @@ cd console_backend/tests && python ../../utils/bench_runner.py --frontend_mem --
 [tasks.newline-terminator]
 env = { EXCLUSION_PATTERNS = [".png", "docs", "resources/images"] }
 private = true
-script_runner = "python"
+script_runner = "${PYTHON}"
 script_extension = "py"
 script = '''
 import os

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -333,7 +333,10 @@ args = ["status"]
 [tasks.build-frontend-wheel]
 dependencies = ["dist-install-pip-flit", "check-git-status"]
 command = "${DIST_PYTHON}"
-args = ["-m", "flit", "build", "--no-setup-py"]
+# --no-setup-py was removed in flit 4.x; it's also already the default
+# behavior (flit stopped generating setup.py a while back), so dropping the
+# flag is forward-compatible instead of pinning flit to a specific version.
+args = ["-m", "flit", "build"]
 
 [tasks.dist-install-pip-setuptools-rust]
 command = "${DIST_PYTHON}"

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ clang by setting an environment variable:
 export BINDGEN_EXTRA_CLANG_ARGS=-I$(xcrun --show-sdk-path)/usr/include
 ```
 
+### Building with Docker
+
+This repository includes a `Dockerfile` which can be used to build and run the Swift Navigation Console on Linux platforms.  See the section [Linux Docker Image](#docker-image) below for more details.
+
 ## Running
 
 To run the app (in dev mode):
@@ -126,6 +130,34 @@ cargo make create-dist
 
 # In order to create an installer:
 cargo make dist-to-installer
+```
+
+## Linux Docker Image
+
+The Linux Docker Image can be built as follows:
+
+```
+docker build --network=host .
+```
+
+Once the image is built, it can be run using:
+
+```
+docker run -it --net=host -v $PWD:/work:rw <image hash>
+```
+
+By default, the image executes the `cargo make setup-builder` and `cargo make create-dist` commands.
+Developers who wish to run other build steps can prevent these commands from running and drop to a shell by providing the `--entrypoint` argument to Docker, i.e.:
+
+```
+docker run -it --net=host --entrypoint /bin/bash -v $PWD:/work:rw <image hash>
+```
+
+It is also possible to build and execute the Swift Navigation Console in-place using a debug build within the Docker image via the `cargo make run` command.
+This requires Docker to be configured to forward the X display to the host, e.g.:
+
+```
+docker run -it --net=host -v $PWD:/work:rw -v /tmp/.X11-unix:/tmp/.X11-unix -v $HOME/.Xauthority:/home/builder/.Xauthority -e DISPLAY=$DISPLAY -h $HOSTNAME --entrypoint /bin/bash <image hash>
 ```
 
 ## Create a new release via CI

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ If you want to run the application without the standard development envionrment.
 pip install flit
 
 # Generate the wheel.
-python -m flit build --no-setup-py
+python -m flit build
 
 # Install the wheel.
 pip install dist/swiftnav_console-0.1.0-py3-none-any.whl --force-reinstall

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ export BINDGEN_EXTRA_CLANG_ARGS=-I$(xcrun --show-sdk-path)/usr/include
 
 ### Building with Docker
 
-This repository includes a `Dockerfile` which can be used to build and run the Swift Navigation Console on Linux platforms.  See the section [Linux Docker Image](#docker-image) below for more details.
+This repository includes a `Dockerfile` which can be used to build and run the Swift Navigation Console on Linux platforms.  See the section [Linux Docker Image](#linux-docker-image) below for more details.
 
 ## Running
 


### PR DESCRIPTION
Add a Docker image which can be used to build or run swift-toolbox on Linux.  Using Docker is preferable to installing the necessary packages natively on the build host, since the build host may have a different version of `rustc` which prevents some of the build dependencies from being installed - in particular, `cargo-make` can only be compiled with rust 1.88 or later, whereas swift-toolbox itself only requires rust 1.78.

There are a number of surprising dependencies required in order to build/run swift-toolbox, including:

* `pkgconf`/`libssl-dev` are required to build the cryptography crate
* `libnss3`/`libasound2`/`libxkbfile` are needed by Qt6
* `xz-utils` is required to create the redistributable bundle

Also includes a fix for `flit` copied from https://github.com/swift-nav/swift-toolbox/pull/1265 to fix compilation of the redistributable bundle.